### PR TITLE
배포 워크플로우

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,32 @@
+name: 🚢 Deployment
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run build
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./dist"
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
디폴트 브랜치에 PR이 병합될 때 마다 자동으로 GitHub Pages에 배포해주는 워크플로우를 추가합니다.

- URL: https://leaderboard.dalestudy.com/
- GitHub Actions 로그:
![Shot 2024-10-25 at 15 31 11@2x](https://github.com/user-attachments/assets/4b26fa27-512f-4b4c-a231-9f89bc6f5c32)

## 테스트

`/`는 잘 작동

![Shot 2024-10-25 at 15 55 19@2x](https://github.com/user-attachments/assets/73bb16e1-343b-4992-a44b-0d3ea75baff5)

`/progress`와 `/certificate`은 404 오류

![Shot 2024-10-25 at 15 55 44@2x](https://github.com/user-attachments/assets/5a8b8784-dcb6-4807-a0a5-7e112105c391)

관련해서 이슈 생성함: https://github.com/DaleStudy/leaderboard/issues/35