### PR TITLE
최소 테스트 커버리지 증가

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,11 +21,12 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     coverage: {
       include: ["src/**/*.ts?(x)"],
+      exclude: ["src/**/*.stories.ts?(x)"],
       thresholds: {
-        lines: 10,
-        functions: 20,
-        statements: 10,
-        branches: 30,
+        lines: 70,
+        functions: 70,
+        statements: 70,
+        branches: 70,
       },
     },
   },


### PR DESCRIPTION
프로젝트 막 셋업햇을 때는 테스트가 별로 없어서 최소 70% 커버리지의 요구사항을 맞추도록 Vitest 설정을 할 수가 없었습니다. 참고: https://github.com/DaleStudy/leaderboard/pull/22#discussion_r1807568374

하지만 그 동안 팀원 분들이 충실히 테스트를 작성해주셔서 현재는 넉넉하게 80%를 넘기고 있는 상황입니다. 그래서 앞으로 계속 이 상태를 유지하기 위해서 Vitest의 coverage threshhold를 목표치인 70%로 늘리도록 하겠습니다.

![Shot 2024-11-07 at 15 50 36@2x](https://github.com/user-attachments/assets/4701e345-775a-4bea-b111-d60a6fb7f2ab)
