### PR TITLE
fix: make github token an environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ coverage
 
 # TypeScript
 *.tsbuildinfo
+
+.env

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -18,6 +18,6 @@ export const CONFIG: Config = {
   gitHub: {
     baseUrl: "https://api.github.com",
     mediaType: "application/vnd.github+json",
-    token: process.env.GITHUB_TOKEN ?? "",
+    token: import.meta.env.VITE_GITHUB_API_TOKEN,
   },
 } as const;


### PR DESCRIPTION
## Changes

개발 환경에서 각자 PAT를 발급하여 Github API를 사용할 수 있도록 합니다.

이 변경사항이 반영되면 각자 .env 파일을 루트 디렉토리에 만든 다음,
```
VITE_GITHUB_API_TOKEN=your_github_pat
```

이런 식으로 VITE_GITHUB_API_TOKEN에 자신의 PAT를 할당해주면 됩니다.

[참고 링크](https://vite.dev/guide/env-and-mode)

## 체크리스트

- [x] 이슈가 연결되어 있나요?
