### PR TITLE
로딩 컴포넌트 구현

### DIFF
--- a/src/components/Leaderboard/Leaderboard.stories.tsx
+++ b/src/components/Leaderboard/Leaderboard.stories.tsx
@@ -1,14 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { http, HttpResponse } from "msw";
+import { delay, http, HttpResponse } from "msw";
 import Leaderboard from "./Leaderboard";
 
 const meta = {
   component: Leaderboard,
-} satisfies Meta<typeof Leaderboard>;
-
-export default meta;
-
-export const Default: StoryObj<typeof meta> = {
   parameters: {
     msw: {
       handlers: [
@@ -52,6 +47,22 @@ export const Default: StoryObj<typeof meta> = {
               },
             ]),
         ),
+      ],
+    },
+  },
+} satisfies Meta<typeof Leaderboard>;
+
+export default meta;
+
+export const Default: StoryObj<typeof meta> = {};
+
+export const Loading: StoryObj<typeof meta> = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("https://api.github.com/orgs/DaleStudy/teams", async () => {
+          await delay("infinite");
+        }),
       ],
     },
   },

--- a/src/components/Leaderboard/Leaderboard.test.tsx
+++ b/src/components/Leaderboard/Leaderboard.test.tsx
@@ -9,7 +9,7 @@ import Leaderboard from "./Leaderboard";
 
 vi.mock("../../hooks/useMembers");
 
-test("render the loading message while fetching members", () => {
+test("render the loading while fetching members", () => {
   vi.mocked(useMembers).mockReturnValue(
     mock({
       isLoading: true,
@@ -23,7 +23,7 @@ test("render the loading message while fetching members", () => {
 
   render(<Leaderboard />);
 
-  expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  expect(screen.getByRole("status")).toHaveAccessibleName(/spinner/i);
 });
 
 test("render the error message while fetching members", () => {

--- a/src/components/Leaderboard/Leaderboard.tsx
+++ b/src/components/Leaderboard/Leaderboard.tsx
@@ -8,6 +8,7 @@ import useMembers, { type Filter } from "../../hooks/useMembers";
 import Card from "../Card/Card";
 
 import styles from "./Leaderboard.module.css";
+import Spinner from "../Spinner/Spinner";
 
 export default function Leaderboard() {
   const { members, isLoading, error, totalCohorts, filter, setFilter } =
@@ -16,7 +17,7 @@ export default function Leaderboard() {
   const handleSearch = ({ name, cohort }: Filter): void =>
     setFilter({ name, cohort });
 
-  if (isLoading) return <p>Loading...</p>; // TODO replace with a proper loading component
+  if (isLoading) return <Spinner />; // TODO replace with a proper loading component
   if (error) return <p>Error!</p>; // TODO replace with a proper error component
 
   const sortedMembers = members.sort((a, b) => b.progress - a.progress);

--- a/src/components/Spinner/Spinner.module.css
+++ b/src/components/Spinner/Spinner.module.css
@@ -1,0 +1,9 @@
+.spinner {
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -3,6 +3,23 @@ import Spinner from "./Spinner";
 
 const meta: Meta<typeof Spinner> = {
   component: Spinner,
+  decorators: [
+    (Story) => {
+      return (
+        <div
+          style={{
+            display: "flex",
+            width: "100vw",
+            height: "100vh",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Story />
+        </div>
+      );
+    },
+  ],
 };
 
 export default meta;

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Spinner from "./Spinner";
+
+const meta: Meta<typeof Spinner> = {
+  component: Spinner,
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof Spinner> = {};

--- a/src/components/Spinner/Spinner.test.tsx
+++ b/src/components/Spinner/Spinner.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import Spinner from "./Spinner";
+
+test("renders the loading", () => {
+  render(<Spinner />);
+  const loading = screen.getByRole("status");
+  expect(loading).toHaveAccessibleName(/spinner/i);
+});

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,0 +1,84 @@
+import { HTMLAttributes } from "react";
+import styles from "./Spinner.module.css";
+
+export default function Spinner({
+  className,
+  ...props
+}: HTMLAttributes<SVGElement>) {
+  return (
+    <svg
+      {...props}
+      role="status"
+      aria-label="spinner"
+      className={`${styles.spinner} ${className}`}
+      width="137"
+      height="138"
+      viewBox="0 0 137 138"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="106.497"
+        cy="109.183"
+        r="12.5"
+        transform="rotate(45 106.497 109.183)"
+        fill="#24EACA"
+        fillOpacity="0.4"
+      />
+      <circle
+        cx="65.9243"
+        cy="125.383"
+        r="12.5"
+        transform="rotate(90 65.9243 125.383)"
+        fill="#24EACA"
+        fillOpacity="0.6"
+      />
+      <circle
+        cx="107.561"
+        cy="28.5789"
+        r="12.5"
+        transform="rotate(45 107.561 28.5789)"
+        fill="#846DE9"
+        fillOpacity="0.8"
+      />
+      <circle
+        cx="123.673"
+        cy="69.1395"
+        r="12.5"
+        transform="rotate(90 123.673 69.1395)"
+        fill="#846DE9"
+      />
+      <circle
+        cx="28.3535"
+        cy="28.9484"
+        r="12.5"
+        transform="rotate(45 28.3535 28.9484)"
+        fill="#846DE9"
+        fillOpacity="0.4"
+      />
+      <circle
+        cx="67.4033"
+        cy="13.3933"
+        r="12.5"
+        transform="rotate(90 67.4033 13.3933)"
+        fill="#846DE9"
+        fillOpacity="0.6"
+      />
+      <circle
+        cx="28.043"
+        cy="106.026"
+        r="12.5"
+        transform="rotate(45 28.043 106.026)"
+        fill="#24EACA"
+        fillOpacity="0.8"
+      />
+      <circle
+        cx="12.6807"
+        cy="67.6741"
+        r="12.5"
+        transform="rotate(90 12.6807 67.6741)"
+        fill="#24EACA"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
로딩 컴포넌트 자체만 구현한 작업입니다.

각 페이지마다 적용하려 했으나 현재 작업중인 페이지가 있어 작업 의존성이 떨어진 리더보드에만 적용했습니다.
추후 풀이현황, 수료증 페이지 작업이 완료되면 컴포넌트를 추가할 예정입니다. 
예시코드라 이해하면 됩니다!

헤더 컴포넌트를 적용하지 않았는데 이 부분은 추후 Layout에서 해결한다고 이해하고 로딩컴포넌트에 집중하여 작업한 PR입니다.

https://github.com/user-attachments/assets/dfd044a7-fc98-4630-a6a2-21957b769252

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?