### PR TITLE
ci: fix chromatic url for main branch

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -36,7 +36,7 @@ jobs:
   chromatic:
     environment:
       name: chromatic
-      url: https://${{ github.head_ref }}--67451d0423c813a4784afd4a.chromatic.com
+      url: https://${{ github.ref_name }}--67451d0423c813a4784afd4a.chromatic.com
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
PR이 병합된 후 Chromatic에 배포된 스토리북 URL이 잘못되서 정정합니다.

![Shot 2024-11-30 at 22 00 36](https://github.com/user-attachments/assets/19001b4a-bedb-4a5f-bd72-88c33686f778)


## 체크리스트

- [x] 이슈가 연결되어 있나요? fix #94 
- [x] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
