### PR TITLE
레이아웃 컴포넌트 사용 위치 조정

### DIFF
--- a/src/certificate.tsx
+++ b/src/certificate.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import Certificate from "./components/Certificate/Certificate";
-import Layout from "./components/Layout/Layout";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <Layout>
-      <Certificate />
-    </Layout>
+    <Certificate />
   </StrictMode>,
 );

--- a/src/components/Certificate/Certificate.tsx
+++ b/src/components/Certificate/Certificate.tsx
@@ -2,6 +2,7 @@ import { getMembers } from "../../api/getMembers";
 import useMembers from "../../hooks/useMembers";
 import Signature from "../../assets/signature.png";
 
+import Layout from "../Layout/Layout";
 import Link from "../Link/Link";
 import Button from "../Button/Button";
 
@@ -22,331 +23,333 @@ export default function Certificate() {
   if (error) return <p>Error!</p>; // TODO replace with a proper error component
 
   return (
-    <main className={styles.certificate}>
-      <section>
-        <div>
-          <h1>수료증</h1>
+    <Layout>
+      <main className={styles.certificate}>
+        <section>
+          <div>
+            <h1>수료증</h1>
 
-          <section className={styles.content}>
-            {/* TODO Icon component 구현시 className에 style값만 추가할 것*/}
-            <div className={styles.contentSide}>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="87"
-                height="88"
-                viewBox="0 0 87 88"
-                fill="none"
+            <section className={styles.content}>
+              {/* TODO Icon component 구현시 className에 style값만 추가할 것*/}
+              <div className={styles.contentSide}>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="87"
+                  height="88"
+                  viewBox="0 0 87 88"
+                  fill="none"
+                >
+                  <path
+                    d="M2 1.99998V85.8899L23.6489 65.8565V25.2625L2 1.99998Z"
+                    fill="url(#paint0_linear_1636_498)"
+                    stroke="url(#paint1_linear_1636_498)"
+                  />
+                  <path
+                    d="M85.7775 2.06592L2.02017 2.06592L23.7554 24.8898L65.7127 23.6809L85.7775 2.06592Z"
+                    fill="url(#paint2_linear_1636_498)"
+                    stroke="url(#paint3_linear_1636_498)"
+                  />
+                  <defs>
+                    <linearGradient
+                      id="paint0_linear_1636_498"
+                      x1="2"
+                      y1="85.8899"
+                      x2="56.0426"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint1_linear_1636_498"
+                      x1="2"
+                      y1="85.8899"
+                      x2="56.0426"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint2_linear_1636_498"
+                      x1="2.02017"
+                      y1="2.06592"
+                      x2="43.78"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint3_linear_1636_498"
+                      x1="2.02017"
+                      y1="2.06592"
+                      x2="43.78"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                  </defs>
+                </svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="87"
+                  height="88"
+                  viewBox="0 0 87 88"
+                  fill="none"
+                  className={styles.reverse}
+                >
+                  <path
+                    d="M85 1.99998V85.8899L63.3511 65.8565V25.2625L85 1.99998Z"
+                    fill="url(#paint0_linear_1636_501)"
+                    stroke="url(#paint1_linear_1636_501)"
+                  />
+                  <path
+                    d="M1.22253 2.06592L84.9798 2.06592L63.2446 24.8898L21.2873 23.6809L1.22253 2.06592Z"
+                    fill="url(#paint2_linear_1636_501)"
+                    stroke="url(#paint3_linear_1636_501)"
+                  />
+                  <defs>
+                    <linearGradient
+                      id="paint0_linear_1636_501"
+                      x1="85"
+                      y1="85.8899"
+                      x2="30.9574"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint1_linear_1636_501"
+                      x1="85"
+                      y1="85.8899"
+                      x2="30.9574"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint2_linear_1636_501"
+                      x1="84.9798"
+                      y1="2.06592"
+                      x2="43.22"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint3_linear_1636_501"
+                      x1="84.9798"
+                      y1="2.06592"
+                      x2="43.22"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                  </defs>
+                </svg>
+              </div>
+
+              <div className={styles.description}>
+                <svg
+                  width="75"
+                  height="36"
+                  viewBox="0 0 75 36"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24.9596 31.05L0.70957 20.35V16.85L24.9596 4.75V10.6L8.25957 18.35L24.9596 25.2V31.05ZM47.5729 0.299998L34.2729 36H27.5229L40.8229 0.299998H47.5729ZM49.9771 25.2L66.6771 18.35L49.9771 10.6V4.75L74.2271 16.85V20.35L49.9771 31.05V25.2Z"
+                    fill="url(#paint0_linear_1647_82)"
+                  />
+                  <defs>
+                    <linearGradient
+                      id="paint0_linear_1647_82"
+                      x1="-5"
+                      y1="16.1219"
+                      x2="80"
+                      y2="16.1219"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                  </defs>
+                </svg>
+
+                <h2>CERTIFICATE OF ACHIEVEMENT</h2>
+                <h3>DaleStudy</h3>
+                <h4>{member?.name}</h4>
+
+                <p>{`For successfully completing ${member?.solvedProblems.length === 75 ? "all" : member?.solvedProblems.length} problems\nin the LeetCode Blind 75 and contributing\nto knowledge sharing in the ${member?.cohort}${cohortSuffix?.[member?.cohort ?? 0] ?? "th"} DaleStudy.`}</p>
+
+                <img src={Signature} alt="signature" />
+                <h5>Dale Seo</h5>
+                <span>DaleStudy Organizer</span>
+              </div>
+
+              <div className={styles.contentSide}>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="87"
+                  height="88"
+                  viewBox="0 0 87 88"
+                  fill="none"
+                >
+                  <path
+                    d="M85 1.99998V85.8899L63.3511 65.8565V25.2625L85 1.99998Z"
+                    fill="url(#paint0_linear_1636_501)"
+                    stroke="url(#paint1_linear_1636_501)"
+                  />
+                  <path
+                    d="M1.22253 2.06592L84.9798 2.06592L63.2446 24.8898L21.2873 23.6809L1.22253 2.06592Z"
+                    fill="url(#paint2_linear_1636_501)"
+                    stroke="url(#paint3_linear_1636_501)"
+                  />
+                  <defs>
+                    <linearGradient
+                      id="paint0_linear_1636_501"
+                      x1="85"
+                      y1="85.8899"
+                      x2="30.9574"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint1_linear_1636_501"
+                      x1="85"
+                      y1="85.8899"
+                      x2="30.9574"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint2_linear_1636_501"
+                      x1="84.9798"
+                      y1="2.06592"
+                      x2="43.22"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint3_linear_1636_501"
+                      x1="84.9798"
+                      y1="2.06592"
+                      x2="43.22"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                  </defs>
+                </svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="87"
+                  height="88"
+                  viewBox="0 0 87 88"
+                  fill="none"
+                  className={styles.reverse}
+                >
+                  <path
+                    d="M2 1.99998V85.8899L23.6489 65.8565V25.2625L2 1.99998Z"
+                    fill="url(#paint0_linear_1636_498)"
+                    stroke="url(#paint1_linear_1636_498)"
+                  />
+                  <path
+                    d="M85.7775 2.06592L2.02017 2.06592L23.7554 24.8898L65.7127 23.6809L85.7775 2.06592Z"
+                    fill="url(#paint2_linear_1636_498)"
+                    stroke="url(#paint3_linear_1636_498)"
+                  />
+                  <defs>
+                    <linearGradient
+                      id="paint0_linear_1636_498"
+                      x1="2"
+                      y1="85.8899"
+                      x2="56.0426"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint1_linear_1636_498"
+                      x1="2"
+                      y1="85.8899"
+                      x2="56.0426"
+                      y2="46.9015"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint2_linear_1636_498"
+                      x1="2.02017"
+                      y1="2.06592"
+                      x2="43.78"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                    <linearGradient
+                      id="paint3_linear_1636_498"
+                      x1="2.02017"
+                      y1="2.06592"
+                      x2="43.78"
+                      y2="56.8834"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="#24EACA" />
+                      <stop offset="1" stopColor="#846DE9" />
+                    </linearGradient>
+                  </defs>
+                </svg>
+              </div>
+            </section>
+
+            <section className={styles.buttons}>
+              <Button
+                variant="primary"
+                size="large"
+                onClick={() => window.print()}
               >
-                <path
-                  d="M2 1.99998V85.8899L23.6489 65.8565V25.2625L2 1.99998Z"
-                  fill="url(#paint0_linear_1636_498)"
-                  stroke="url(#paint1_linear_1636_498)"
-                />
-                <path
-                  d="M85.7775 2.06592L2.02017 2.06592L23.7554 24.8898L65.7127 23.6809L85.7775 2.06592Z"
-                  fill="url(#paint2_linear_1636_498)"
-                  stroke="url(#paint3_linear_1636_498)"
-                />
-                <defs>
-                  <linearGradient
-                    id="paint0_linear_1636_498"
-                    x1="2"
-                    y1="85.8899"
-                    x2="56.0426"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint1_linear_1636_498"
-                    x1="2"
-                    y1="85.8899"
-                    x2="56.0426"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint2_linear_1636_498"
-                    x1="2.02017"
-                    y1="2.06592"
-                    x2="43.78"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint3_linear_1636_498"
-                    x1="2.02017"
-                    y1="2.06592"
-                    x2="43.78"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                </defs>
-              </svg>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="87"
-                height="88"
-                viewBox="0 0 87 88"
-                fill="none"
-                className={styles.reverse}
-              >
-                <path
-                  d="M85 1.99998V85.8899L63.3511 65.8565V25.2625L85 1.99998Z"
-                  fill="url(#paint0_linear_1636_501)"
-                  stroke="url(#paint1_linear_1636_501)"
-                />
-                <path
-                  d="M1.22253 2.06592L84.9798 2.06592L63.2446 24.8898L21.2873 23.6809L1.22253 2.06592Z"
-                  fill="url(#paint2_linear_1636_501)"
-                  stroke="url(#paint3_linear_1636_501)"
-                />
-                <defs>
-                  <linearGradient
-                    id="paint0_linear_1636_501"
-                    x1="85"
-                    y1="85.8899"
-                    x2="30.9574"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint1_linear_1636_501"
-                    x1="85"
-                    y1="85.8899"
-                    x2="30.9574"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint2_linear_1636_501"
-                    x1="84.9798"
-                    y1="2.06592"
-                    x2="43.22"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint3_linear_1636_501"
-                    x1="84.9798"
-                    y1="2.06592"
-                    x2="43.22"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                </defs>
-              </svg>
-            </div>
+                출력
+              </Button>
 
-            <div className={styles.description}>
-              <svg
-                width="75"
-                height="36"
-                viewBox="0 0 75 36"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24.9596 31.05L0.70957 20.35V16.85L24.9596 4.75V10.6L8.25957 18.35L24.9596 25.2V31.05ZM47.5729 0.299998L34.2729 36H27.5229L40.8229 0.299998H47.5729ZM49.9771 25.2L66.6771 18.35L49.9771 10.6V4.75L74.2271 16.85V20.35L49.9771 31.05V25.2Z"
-                  fill="url(#paint0_linear_1647_82)"
-                />
-                <defs>
-                  <linearGradient
-                    id="paint0_linear_1647_82"
-                    x1="-5"
-                    y1="16.1219"
-                    x2="80"
-                    y2="16.1219"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                </defs>
-              </svg>
-
-              <h2>CERTIFICATE OF ACHIEVEMENT</h2>
-              <h3>DaleStudy</h3>
-              <h4>{member?.name}</h4>
-
-              <p>{`For successfully completing ${member?.solvedProblems.length === 75 ? "all" : member?.solvedProblems.length} problems\nin the LeetCode Blind 75 and contributing\nto knowledge sharing in the ${member?.cohort}${cohortSuffix?.[member?.cohort ?? 0] ?? "th"} DaleStudy.`}</p>
-
-              <img src={Signature} alt="signature" />
-              <h5>Dale Seo</h5>
-              <span>DaleStudy Organizer</span>
-            </div>
-
-            <div className={styles.contentSide}>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="87"
-                height="88"
-                viewBox="0 0 87 88"
-                fill="none"
-              >
-                <path
-                  d="M85 1.99998V85.8899L63.3511 65.8565V25.2625L85 1.99998Z"
-                  fill="url(#paint0_linear_1636_501)"
-                  stroke="url(#paint1_linear_1636_501)"
-                />
-                <path
-                  d="M1.22253 2.06592L84.9798 2.06592L63.2446 24.8898L21.2873 23.6809L1.22253 2.06592Z"
-                  fill="url(#paint2_linear_1636_501)"
-                  stroke="url(#paint3_linear_1636_501)"
-                />
-                <defs>
-                  <linearGradient
-                    id="paint0_linear_1636_501"
-                    x1="85"
-                    y1="85.8899"
-                    x2="30.9574"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint1_linear_1636_501"
-                    x1="85"
-                    y1="85.8899"
-                    x2="30.9574"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint2_linear_1636_501"
-                    x1="84.9798"
-                    y1="2.06592"
-                    x2="43.22"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint3_linear_1636_501"
-                    x1="84.9798"
-                    y1="2.06592"
-                    x2="43.22"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                </defs>
-              </svg>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="87"
-                height="88"
-                viewBox="0 0 87 88"
-                fill="none"
-                className={styles.reverse}
-              >
-                <path
-                  d="M2 1.99998V85.8899L23.6489 65.8565V25.2625L2 1.99998Z"
-                  fill="url(#paint0_linear_1636_498)"
-                  stroke="url(#paint1_linear_1636_498)"
-                />
-                <path
-                  d="M85.7775 2.06592L2.02017 2.06592L23.7554 24.8898L65.7127 23.6809L85.7775 2.06592Z"
-                  fill="url(#paint2_linear_1636_498)"
-                  stroke="url(#paint3_linear_1636_498)"
-                />
-                <defs>
-                  <linearGradient
-                    id="paint0_linear_1636_498"
-                    x1="2"
-                    y1="85.8899"
-                    x2="56.0426"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint1_linear_1636_498"
-                    x1="2"
-                    y1="85.8899"
-                    x2="56.0426"
-                    y2="46.9015"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint2_linear_1636_498"
-                    x1="2.02017"
-                    y1="2.06592"
-                    x2="43.78"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                  <linearGradient
-                    id="paint3_linear_1636_498"
-                    x1="2.02017"
-                    y1="2.06592"
-                    x2="43.78"
-                    y2="56.8834"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#24EACA" />
-                    <stop offset="1" stopColor="#846DE9" />
-                  </linearGradient>
-                </defs>
-              </svg>
-            </div>
-          </section>
-
-          <section className={styles.buttons}>
-            <Button
-              variant="primary"
-              size="large"
-              onClick={() => window.print()}
-            >
-              출력
-            </Button>
-
-            <Link variant="primaryButton" href={linkedInURL}>
-              링크드인 공유
-            </Link>
-          </section>
-        </div>
-      </section>
-    </main>
+              <Link variant="primaryButton" href={linkedInURL}>
+                링크드인 공유
+              </Link>
+            </section>
+          </div>
+        </section>
+      </main>
+    </Layout>
   );
 }

--- a/src/components/Leaderboard/Leaderboard.tsx
+++ b/src/components/Leaderboard/Leaderboard.tsx
@@ -1,12 +1,12 @@
-import SearchBar from "../SearchBar/SearchBar";
-
 import { getMembers } from "../../api/getMembers";
 import useMembers, { type Filter } from "../../hooks/useMembers";
 
 import Card from "../Card/Card";
+import Layout from "../Layout/Layout";
+import SearchBar from "../SearchBar/SearchBar";
+import Spinner from "../Spinner/Spinner";
 
 import styles from "./Leaderboard.module.css";
-import Spinner from "../Spinner/Spinner";
 
 export default function Leaderboard() {
   const { members, isLoading, error, totalCohorts, filter, setFilter } =
@@ -21,30 +21,32 @@ export default function Leaderboard() {
   const sortedMembers = members.sort((a, b) => b.progress - a.progress);
 
   return (
-    <main className={styles.leaderboard}>
-      <div className={styles.contentWrapper}>
-        <section className={styles.toolbar}>
-          <h1>리더보드</h1>
-          <SearchBar
-            filter={filter}
-            onSearch={handleSearch}
-            totalCohorts={totalCohorts}
-          />
-        </section>
+    <Layout>
+      <main className={styles.leaderboard}>
+        <div className={styles.contentWrapper}>
+          <section className={styles.toolbar}>
+            <h1>리더보드</h1>
+            <SearchBar
+              filter={filter}
+              onSearch={handleSearch}
+              totalCohorts={totalCohorts}
+            />
+          </section>
 
-        <ul>
-          {sortedMembers.map((member) => (
-            <li key={member.id}>
-              <Card
-                id={member.id}
-                name={member.name}
-                cohort={member.cohort}
-                grade={member.grade}
-              />
-            </li>
-          ))}
-        </ul>
-      </div>
-    </main>
+          <ul>
+            {sortedMembers.map((member) => (
+              <li key={member.id}>
+                <Card
+                  id={member.id}
+                  name={member.name}
+                  cohort={member.cohort}
+                  grade={member.grade}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
+    </Layout>
   );
 }

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,3 +1,4 @@
+import Layout from "../Layout/Layout";
 import Sidebar from "../Sidebar/Sidebar";
 import Footer from "../Footer/Footer";
 import Header from "../Header/Header";
@@ -55,30 +56,35 @@ export default function Progress() {
   const profileUrl = member.profileUrl || "Logo.png";
 
   return (
-    <main className={styles.progress}>
-      <Header />
-      <h1>풀이 현황</h1>
-      <div className={styles.container}>
-        <section className={styles.sideBar} aria-labelledby="profile">
-          <Sidebar
-            githubUsername={member.name}
-            easyProgress={easyProgress}
-            mediumProgress={mediumProgress}
-            hardProgress={hardProgress}
-            solvedProblems={totalSolved}
-            totalProblems={totalProblems}
-            profileUrl={profileUrl}
-            cohort={cohort}
-            grade={grade}
-          />
-        </section>
+    <Layout>
+      <main className={styles.progress}>
+        <Header />
+        <h1>풀이 현황</h1>
+        <div className={styles.container}>
+          <section className={styles.sideBar} aria-labelledby="profile">
+            <Sidebar
+              githubUsername={member.name}
+              easyProgress={easyProgress}
+              mediumProgress={mediumProgress}
+              hardProgress={hardProgress}
+              solvedProblems={totalSolved}
+              totalProblems={totalProblems}
+              profileUrl={profileUrl}
+              cohort={cohort}
+              grade={grade}
+            />
+          </section>
 
-        <section className={styles.problemList} aria-labelledby="problem-list">
-          <Table problems={problems} solvedProblems={member.solvedProblems} />
-        </section>
-      </div>
+          <section
+            className={styles.problemList}
+            aria-labelledby="problem-list"
+          >
+            <Table problems={problems} solvedProblems={member.solvedProblems} />
+          </section>
+        </div>
 
-      <Footer />
-    </main>
+        <Footer />
+      </main>
+    </Layout>
   );
 }

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,7 +1,5 @@
 import Layout from "../Layout/Layout";
 import Sidebar from "../Sidebar/Sidebar";
-import Footer from "../Footer/Footer";
-import Header from "../Header/Header";
 import { Table } from "../Table/Table";
 import { getMembers } from "../../api/getMembers";
 import {
@@ -58,7 +56,6 @@ export default function Progress() {
   return (
     <Layout>
       <main className={styles.progress}>
-        <Header />
         <h1>풀이 현황</h1>
         <div className={styles.container}>
           <section className={styles.sideBar} aria-labelledby="profile">
@@ -82,8 +79,6 @@ export default function Progress() {
             <Table problems={problems} solvedProblems={member.solvedProblems} />
           </section>
         </div>
-
-        <Footer />
       </main>
     </Layout>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import Layout from "./components/Layout/Layout";
 import Leaderboard from "./components/Leaderboard/Leaderboard";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <Layout>
-      <Leaderboard />
-    </Layout>
+    <Leaderboard />
   </StrictMode>,
 );

--- a/src/progress.tsx
+++ b/src/progress.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import Layout from "./components/Layout/Layout";
 import Progress from "./components/Progress/Progress";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <Layout>
-      <Progress />
-    </Layout>
+    <Progress />
   </StrictMode>,
 );


### PR DESCRIPTION
PR #103에서 레이아웃 컴포넌트가 추가되면서 페이지 수준의 컴포넌트의 스토리에서 헤더와 풋터가 사라지게 되었습니다. 자세한 차이점은 아래 Chromatic UI Tests 결과를 참고 바랍니다.

https://www.chromatic.com/review?appId=67451d0423c813a4784afd4a&number=103&type=linked&view=changes


![Shot 2024-12-07 at 17 55 55](https://github.com/user-attachments/assets/0312ba39-a4e7-4a71-9d5b-a78718a9823b)

![Shot 2024-12-07 at 17 56 28](https://github.com/user-attachments/assets/c88a0b33-b26a-49c4-b222-355ca8f5426a)

페이지 수준의 컴포넌트의 스토리에서 헤더와 풋터가 없으면 스토리북을 통해서 각 페이지의 `<main>` 요소가 헤더와 풋터와 조합되어 있을 때 어떻게 보이는지 확인하기가 어렵습니다. 따라서 페이지 레벨 컴포넌트를 테스트를 하려면 전체 앱을 올려야 하는 불편이 발생하고, Chromatic도 헤더와 풋터와 조합된 모습에 대한 UI Regression을 잡아내지 못하게 됩니다. 이러한 문제를 해결하기 위해서 레이아웃 컴포넌트가 각 페이지 안으로 들어가도록 위치를 조정하였습니다.

## 체크리스트

- [x] 이슈가 연결되어 있나요? fix #97
- [x] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
