### PR TITLE
fix: 멤버카드가 홀수일 때 너비이슈

### DIFF
--- a/src/components/Leaderboard/Leaderboard.module.css
+++ b/src/components/Leaderboard/Leaderboard.module.css
@@ -20,7 +20,7 @@
     margin-bottom: 60px;
 
     li {
-      flex: 1;
+      flex-basis: calc(calc(100% - 25px) / 2);
     }
   }
 }


### PR DESCRIPTION
### before
![image](https://github.com/user-attachments/assets/3726626f-3bbc-4e76-acb1-2b499c18ff07)


### after
![image](https://github.com/user-attachments/assets/bab77390-16f7-4fd0-96c6-8487702de547)

카드 너비에 대해서만 대응합니다. (반응형 X)

## 체크리스트

- [ ] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
