### PR TITLE
서버 에러 UI 적용

### DIFF
--- a/src/components/ServerError/ServerError.module.css
+++ b/src/components/ServerError/ServerError.module.css
@@ -4,6 +4,7 @@
   row-gap: 36px;
   align-items: center;
 
+  height: 100%;
   width: 100%;
   text-align: center;
 

--- a/src/components/ServerError/ServerError.module.css
+++ b/src/components/ServerError/ServerError.module.css
@@ -1,0 +1,21 @@
+.serverError {
+  display: flex;
+  flex-direction: column;
+  row-gap: 36px;
+  align-items: center;
+
+  width: 100%;
+  text-align: center;
+
+  h2 {
+    font-size: 80px;
+    font-weight: bold;
+    color: var(--primary);
+  }
+
+  p {
+    font-size: 21px;
+    font-weight: normal;
+    color: var(--text-900);
+  }
+}

--- a/src/components/ServerError/ServerError.stories.tsx
+++ b/src/components/ServerError/ServerError.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ServerError from "./ServerError";
+
+const meta = {
+  component: ServerError,
+} satisfies Meta<typeof ServerError>;
+
+export default meta;
+
+export const Default: StoryObj<typeof meta> = {
+  args: {},
+};

--- a/src/components/ServerError/ServerError.test.tsx
+++ b/src/components/ServerError/ServerError.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import ServerError from "./ServerError";
+
+test("renders the error description", () => {
+  render(<ServerError />);
+
+  expect(screen.getByText("Error")).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      "오류가 발생했습니다. 문제가 지속된다면 아래 Github Issue를 방문하여 문제를 보고하거나 진행 상황을 확인해 주시면 감사하겠습니다.",
+    ),
+  ).toBeInTheDocument();
+});
+
+test("renders the button to go to the project github issue page", () => {
+  render(<ServerError />);
+
+  const reportLink = screen.getByRole("link", { name: "문제 보고하기" });
+  expect(reportLink).toBeInTheDocument();
+  expect(reportLink).toHaveAttribute(
+    "href",
+    "https://github.com/DaleStudy/leaderboard/issues",
+  );
+});

--- a/src/components/ServerError/ServerError.tsx
+++ b/src/components/ServerError/ServerError.tsx
@@ -1,0 +1,23 @@
+import Button from "../Button/Button";
+
+import styles from "./ServerError.module.css";
+
+export default function ServerError() {
+  return (
+    <section className={styles.serverError}>
+      <h2>Error</h2>
+      <p>
+        오류가 발생했습니다. 문제가 지속된다면 아래 Github Issue를 방문하여{" "}
+        <br />
+        문제를 보고하거나 진행 상황을 확인해 주시면 감사하겠습니다.
+      </p>
+      <a
+        href="https://github.com/DaleStudy/leaderboard/issues"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Button variant="secondary">문제 보고하기</Button>
+      </a>
+    </section>
+  );
+}

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -20,6 +20,10 @@ aside {
   background-color: var(--bg-200);
   border-radius: 10px;
   box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.1);
+
+  &.error {
+    height: 750px;
+  }
 }
 
 .profile {

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -20,7 +20,20 @@ const meta = {
 
 export default meta;
 
-export const Default: StoryObj<typeof meta> = {};
+export const Default: StoryObj<typeof meta> = {
+  args: {
+    easyProgress: "5/10",
+    mediumProgress: "8/10",
+    hardProgress: "3/5",
+    solvedProblems: 16,
+    totalProblems: 25,
+    grade: Grade.LEAF,
+    cohorts: [1, 2, 3],
+    currentCohort: 3,
+    githubUsername: "testuser",
+    profileUrl: "https://avatars.githubusercontent.com/u/104721736?v=4",
+  },
+};
 
 export const HighProgress: StoryObj<typeof meta> = {
   args: {
@@ -30,6 +43,10 @@ export const HighProgress: StoryObj<typeof meta> = {
     mediumProgress: "10/10",
     hardProgress: "8/10",
     grade: Grade.FRUIT,
+    currentCohort: 3,
+    cohorts: [1, 2, 3],
+    githubUsername: "testuser",
+    profileUrl: "https://avatars.githubusercontent.com/u/104721736?v=4",
   },
 };
 
@@ -41,5 +58,15 @@ export const NoProblems: StoryObj<typeof meta> = {
     solvedProblems: 0,
     totalProblems: 0,
     grade: Grade.SEED,
+    currentCohort: 3,
+    cohorts: [1, 2, 3],
+    githubUsername: "testuser",
+    profileUrl: "https://avatars.githubusercontent.com/u/104721736?v=4",
+  },
+};
+
+export const Error: StoryObj<typeof meta> = {
+  args: {
+    isError: true,
   },
 };

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -33,3 +33,22 @@ test("renders Sidebar with all elements", () => {
   });
   expect(buttonLink).toBeInTheDocument();
 });
+
+test("renders empty Sidebar when error", () => {
+  render(<Sidebar isError />);
+
+  const sidebar = screen.getByRole("complementary");
+  expect(sidebar).toBeInTheDocument();
+
+  expect(
+    screen.queryByRole("link", {
+      name: /풀이 보기/i,
+    }),
+  ).not.toBeInTheDocument();
+
+  expect(
+    screen.queryByRole("link", {
+      name: /리더보드로 돌아가기/i,
+    }),
+  ).not.toBeInTheDocument();
+});

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,13 +1,21 @@
 import { useEffect, useRef } from "react";
-import styles from "./Sidebar.module.css";
+
+import { Grade } from "../../api/services/types";
+
+import Github from "../../assets/Github.png";
+import LargeTree from "../../assets/LargeTree.png";
 import Seed from "../../assets/Seed.png";
 import Sprout from "../../assets/Sprout.png";
 import YoungTree from "../../assets/YoungTree.png";
-import LargeTree from "../../assets/LargeTree.png";
-import Github from "../../assets/Github.png";
-import { Grade } from "../../api/services/types";
 
-interface SidebarProps {
+import styles from "./Sidebar.module.css";
+
+interface SidebarErrorProps {
+  isError: true;
+}
+
+interface SidebarNormalProps {
+  isError?: false; // optional or explicitly false
   githubUsername: string;
   easyProgress: string;
   mediumProgress: string;
@@ -20,6 +28,8 @@ interface SidebarProps {
   grade: Grade;
 }
 
+type SidebarProps = SidebarErrorProps | SidebarNormalProps;
+
 const imageTable = {
   SEED: Seed,
   SPROUT: Sprout,
@@ -29,20 +39,11 @@ const imageTable = {
   TREE: LargeTree,
 };
 
-export default function Sidebar({
-  githubUsername,
-  easyProgress,
-  mediumProgress,
-  hardProgress,
-  solvedProblems,
-  totalProblems,
-  profileUrl,
-  currentCohort,
-  cohorts,
-  grade,
-}: SidebarProps) {
+export default function Sidebar(props: SidebarProps) {
   const progressContainerRef = useRef<HTMLDivElement>(null);
-  const progressPercent = Math.min((solvedProblems / totalProblems) * 100, 100);
+  const progressPercent = props.isError
+    ? 0
+    : Math.min((props.solvedProblems / props.totalProblems) * 100, 100);
 
   useEffect(() => {
     if (progressContainerRef.current) {
@@ -52,6 +53,26 @@ export default function Sidebar({
       );
     }
   }, [progressPercent]);
+
+  if (props.isError) {
+    return (
+      <aside>
+        <div className={`${styles.container} ${styles.error}`}></div>
+      </aside>
+    );
+  }
+
+  const {
+    githubUsername,
+    easyProgress,
+    mediumProgress,
+    hardProgress,
+    solvedProblems,
+    profileUrl,
+    currentCohort,
+    cohorts,
+    grade,
+  } = props;
 
   const taskProgress = [
     { label: "EASY", progress: easyProgress, className: styles.easy },

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -66,3 +66,11 @@ tr:nth-child(even) {
   text-align: center;
   width: 23%;
 }
+
+.serverErrorWrapper {
+  td {
+    padding-top: 170px;
+    padding-bottom: 400px;
+    background-color: var(--bg-100);
+  }
+}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -121,3 +121,11 @@ export const NoCompleted: StoryObj<typeof Table> = {
     solvedProblems: [],
   },
 };
+
+export const Error: StoryObj<typeof Table> = {
+  args: {
+    problems: [],
+    solvedProblems: [],
+    isError: true,
+  },
+};

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
 import { Table } from "./Table";
 
 const problems = [
@@ -55,4 +55,20 @@ test("renders icon for completed/incomplete problems", () => {
     const icon = within(row).getByLabelText(iconLabel);
     expect(icon).toBeInTheDocument();
   });
+});
+
+test("renders error UI when isError is true", () => {
+  render(<Table problems={[]} solvedProblems={[]} isError />);
+
+  expect(screen.getByText("Error")).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      "오류가 발생했습니다. 문제가 지속된다면 아래 Github Issue를 방문하여 문제를 보고하거나 진행 상황을 확인해 주시면 감사하겠습니다.",
+    ),
+  ).toBeInTheDocument();
+  expect(screen.getByText("문제 보고하기")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "문제 보고하기" })).toHaveAttribute(
+    "href",
+    "https://github.com/DaleStudy/leaderboard/issues",
+  );
 });

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+import ServerError from "../ServerError/ServerError";
 import styles from "./Table.module.css";
 
 interface Problem {
@@ -9,9 +10,14 @@ interface Problem {
 interface TableProps {
   problems: Problem[];
   solvedProblems: Problem[];
+  isError?: boolean;
 }
 
-export function Table({ problems, solvedProblems }: TableProps) {
+export function Table({
+  problems,
+  solvedProblems,
+  isError = false,
+}: TableProps) {
   return (
     <table className={styles.table}>
       <thead>
@@ -35,40 +41,50 @@ export function Table({ problems, solvedProblems }: TableProps) {
           </th>
         </tr>
       </thead>
-      <tbody>
-        {problems.map((problem) => {
-          const isCompleted = solvedProblems.some(
-            (solved) => solved.id === problem.id,
-          );
-          const problemIcon = getTaskIcon(isCompleted);
-          const difficultyClass = getDifficultyClass(problem.difficulty);
+      {isError ? (
+        <tbody className={styles.serverErrorWrapper}>
+          <tr>
+            <td colSpan={3}>
+              <ServerError />
+            </td>
+          </tr>
+        </tbody>
+      ) : (
+        <tbody>
+          {problems.map((problem) => {
+            const isCompleted = solvedProblems.some(
+              (solved) => solved.id === problem.id,
+            );
+            const problemIcon = getTaskIcon(isCompleted);
+            const difficultyClass = getDifficultyClass(problem.difficulty);
 
-          const formattedTitle = problem.title.replace(/-/g, " ");
+            const formattedTitle = problem.title.replace(/-/g, " ");
 
-          // Add a period to "Med" only
-          const difficultyLabel =
-            problem.difficulty === "Med"
-              ? `${problem.difficulty}.`
-              : problem.difficulty;
+            // Add a period to "Med" only
+            const difficultyLabel =
+              problem.difficulty === "Med"
+                ? `${problem.difficulty}.`
+                : problem.difficulty;
 
-          return (
-            <tr key={problem.id}>
-              <td className={styles.problemData}>
-                {problem.id}. {formattedTitle}
-              </td>
-              <td className={`${styles.difficultyData} ${difficultyClass}`}>
-                {difficultyLabel}
-              </td>
-              <td
-                className={styles.statusData}
-                aria-label={isCompleted ? "완료" : "미완료"}
-              >
-                {problemIcon}
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
+            return (
+              <tr key={problem.id}>
+                <td className={styles.problemData}>
+                  {problem.id}. {formattedTitle}
+                </td>
+                <td className={`${styles.difficultyData} ${difficultyClass}`}>
+                  {difficultyLabel}
+                </td>
+                <td
+                  className={styles.statusData}
+                  aria-label={isCompleted ? "완료" : "미완료"}
+                >
+                  {problemIcon}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      )}
     </table>
   );
 }

--- a/src/pages/Certificate/Certificate.module.css
+++ b/src/pages/Certificate/Certificate.module.css
@@ -116,3 +116,8 @@
     font-size: 20px;
   }
 }
+
+.serverErrorWrapper {
+  margin-top: 160px;
+  margin-bottom: 300px;
+}

--- a/src/pages/Certificate/Certificate.stories.tsx
+++ b/src/pages/Certificate/Certificate.stories.tsx
@@ -35,8 +35,35 @@ export const Default: StoryObj<typeof Certificate> = {};
 
 export const NotFound: StoryObj<typeof meta> = {
   parameters: {
+    msw: {
+      handlers: [
+        http.get("https://api.github.com/orgs/DaleStudy/teams", () =>
+          HttpResponse.json([{ name: "leetcode02" }]),
+        ),
+        http.get(
+          "https://api.github.com/orgs/DaleStudy/teams/leetcode02/members",
+          () => HttpResponse.json([]),
+        ),
+      ],
+    },
     query: {
       member: "sunjae9",
+    },
+  },
+};
+
+export const ServerError: StoryObj<typeof meta> = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("https://api.github.com/orgs/DaleStudy/teams", () =>
+          HttpResponse.error(),
+        ),
+        http.get(
+          "https://api.github.com/orgs/DaleStudy/teams/leetcode02/members",
+          () => HttpResponse.error(),
+        ),
+      ],
     },
   },
 };

--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -237,3 +237,30 @@ test("render LinkedIn link", () => {
     `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=테스트1&organizationId=104834174&certUrl=${encodeURIComponent(location.href)}`,
   );
 });
+
+test("render the error message while fetching members", () => {
+  vi.mocked(useMembers).mockReturnValue(
+    mock({
+      isLoading: false,
+      error: new Error(),
+      members: [],
+      totalCohorts: 0,
+      filter: { name: "", cohort: null },
+      setFilter: vi.fn(),
+    }),
+  );
+
+  render(<Certificate />);
+
+  expect(screen.getByText(/error/i)).toBeInTheDocument();
+  expect(screen.getByText(/오류가 발생했습니다/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      /문제가 지속된다면 아래 Github Issue를 방문하여 문제를 보고하거나 진행 상황을 확인해 주시면 감사하겠습니다./i,
+    ),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /문제 보고하기/i })).toHaveAttribute(
+    "href",
+    "https://github.com/DaleStudy/leaderboard/issues",
+  );
+});

--- a/src/pages/Certificate/Certificate.tsx
+++ b/src/pages/Certificate/Certificate.tsx
@@ -8,6 +8,7 @@ import Link from "../../components/Link/Link";
 import NotFound from "../../components/NotFound/NotFound";
 
 import styles from "./Certificate.module.css";
+import ServerError from "../../components/ServerError/ServerError";
 
 const cohortSuffix = ["th", "st", "nd", "rd"];
 
@@ -15,7 +16,23 @@ export default function Certificate() {
   const { members, isLoading, error } = useMembers({ getMembers });
 
   if (isLoading) return <p>Loading...</p>; // TODO replace with a proper loading component
-  if (error) return <p>Error!</p>; // TODO replace with a proper error component
+
+  if (error) {
+    return (
+      <Layout>
+        <main className={styles.certificate}>
+          <section>
+            <div>
+              <h1>수료증</h1>
+              <section className={styles.serverErrorWrapper}>
+                <ServerError />;
+              </section>
+            </div>
+          </section>
+        </main>
+      </Layout>
+    );
+  }
 
   const member = members.find(
     ({ id }) =>

--- a/src/pages/Leaderboard/Leaderboard.module.css
+++ b/src/pages/Leaderboard/Leaderboard.module.css
@@ -46,3 +46,9 @@
     font-size: 24px;
   }
 }
+
+.serverErrorWrapper {
+  width: 100%;
+  margin-top: 240px;
+  margin-bottom: 340px;
+}

--- a/src/pages/Leaderboard/Leaderboard.stories.tsx
+++ b/src/pages/Leaderboard/Leaderboard.stories.tsx
@@ -67,3 +67,19 @@ export const Loading: StoryObj<typeof meta> = {
     },
   },
 };
+
+export const ServerError: StoryObj<typeof meta> = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("https://api.github.com/orgs/DaleStudy/teams", () =>
+          HttpResponse.error(),
+        ),
+        http.get(
+          "https://api.github.com/orgs/DaleStudy/teams/leetcode02/members",
+          () => HttpResponse.error(),
+        ),
+      ],
+    },
+  },
+};

--- a/src/pages/Leaderboard/Leaderboard.test.tsx
+++ b/src/pages/Leaderboard/Leaderboard.test.tsx
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { render, screen } from "@testing-library/react";
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { type Member, Grade } from "../../api/services/types";
@@ -26,21 +26,54 @@ test("render the loading while fetching members", () => {
   expect(screen.getByRole("status")).toHaveAccessibleName(/스피너/i);
 });
 
-test("render the error message while fetching members", () => {
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: new Error(),
-      members: [],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+describe("error occurred while fetching members", () => {
+  test("render the error message", () => {
+    vi.mocked(useMembers).mockReturnValue(
+      mock({
+        error: new Error(),
 
-  render(<Leaderboard />);
+        isLoading: false,
+        members: [],
+        totalCohorts: 0,
+        filter: { name: "", cohort: null },
+        setFilter: vi.fn(),
+      }),
+    );
 
-  expect(screen.getByText(/error/i)).toBeInTheDocument();
+    render(<Leaderboard />);
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Error",
+    );
+    expect(
+      screen.getByText(
+        "오류가 발생했습니다. 문제가 지속된다면 아래 Github Issue를 방문하여 문제를 보고하거나 진행 상황을 확인해 주시면 감사하겠습니다.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("render the report issue link", () => {
+    vi.mocked(useMembers).mockReturnValue(
+      mock({
+        error: new Error(),
+
+        isLoading: false,
+        members: [],
+        totalCohorts: 0,
+        filter: { name: "", cohort: null },
+        setFilter: vi.fn(),
+      }),
+    );
+
+    render(<Leaderboard />);
+
+    const reportLink = screen.getByRole("link", { name: "문제 보고하기" });
+    expect(reportLink).toBeInTheDocument();
+    expect(reportLink).toHaveAttribute(
+      "href",
+      "https://github.com/DaleStudy/leaderboard/issues",
+    );
+  });
 });
 
 test("render the page title", () => {

--- a/src/pages/Leaderboard/Leaderboard.tsx
+++ b/src/pages/Leaderboard/Leaderboard.tsx
@@ -4,6 +4,7 @@ import useMembers, { type Filter } from "../../hooks/useMembers";
 import Card from "../../components/Card/Card";
 import Layout from "../../components/Layout/Layout";
 import SearchBar from "../../components/SearchBar/SearchBar";
+import ServerError from "../../components/ServerError/ServerError";
 import Spinner from "../../components/Spinner/Spinner";
 
 import styles from "./Leaderboard.module.css";
@@ -16,9 +17,6 @@ export default function Leaderboard() {
     setFilter({ name, cohort });
 
   if (isLoading) return <Spinner />; // TODO replace with a proper loading component
-  if (error) return <p>Error!</p>; // TODO replace with a proper error component
-
-  const sortedMembers = members.sort((a, b) => b.progress - a.progress);
 
   return (
     <Layout>
@@ -33,19 +31,27 @@ export default function Leaderboard() {
             />
           </section>
 
-          <ul>
-            {sortedMembers.map((member) => (
-              <li key={member.id}>
-                <Card
-                  id={member.id}
-                  name={member.name}
-                  currentCohort={member.currentCohort}
-                  cohorts={member.cohorts}
-                  grade={member.grade}
-                />
-              </li>
-            ))}
-          </ul>
+          {error ? (
+            <div className={styles.serverErrorWrapper}>
+              <ServerError />
+            </div>
+          ) : (
+            <ul>
+              {members
+                .sort((a, b) => b.progress - a.progress)
+                .map((member) => (
+                  <li key={member.id}>
+                    <Card
+                      id={member.id}
+                      name={member.name}
+                      currentCohort={member.currentCohort}
+                      cohorts={member.cohorts}
+                      grade={member.grade}
+                    />
+                  </li>
+                ))}
+            </ul>
+          )}
         </div>
       </main>
     </Layout>

--- a/src/pages/Progress/Progress.module.css
+++ b/src/pages/Progress/Progress.module.css
@@ -20,6 +20,6 @@ h1 {
   width: 20%;
 }
 
-.problemList {
+.problemTableWrapper {
   width: 75%;
 }

--- a/src/pages/Progress/Progress.stories.tsx
+++ b/src/pages/Progress/Progress.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import Progress from "./Progress";
 import { http, HttpResponse } from "msw";
+import Progress from "./Progress";
 
 const meta: Meta<typeof Progress> = {
   component: Progress,
@@ -31,12 +31,20 @@ const meta: Meta<typeof Progress> = {
 
 export default meta;
 
-export const Default: StoryObj<typeof meta> = {};
+export const Default: StoryObj<typeof Progress> = {};
 
-export const NotFound: StoryObj<typeof meta> = {
+export const ServerError: StoryObj<typeof meta> = {
   parameters: {
-    query: {
-      member: "sunjae9",
+    msw: {
+      handlers: [
+        http.get("https://api.github.com/orgs/DaleStudy/teams", () =>
+          HttpResponse.error(),
+        ),
+        http.get(
+          "https://api.github.com/orgs/DaleStudy/teams/leetcode02/members",
+          () => HttpResponse.error(),
+        ),
+      ],
     },
   },
 };

--- a/src/pages/Progress/Progress.test.tsx
+++ b/src/pages/Progress/Progress.test.tsx
@@ -1,11 +1,11 @@
 import { faker } from "@faker-js/faker";
-import { expect } from "vitest";
-import { render, screen } from "@testing-library/react";
-import Progress from "./Progress";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
-import useMembers from "../../hooks/useMembers";
-import { test, vi } from "vitest";
+
 import { type Member, Grade } from "../../api/services/types";
+import useMembers from "../../hooks/useMembers";
+import Progress from "./Progress";
 
 vi.mock("../../hooks/useMembers");
 
@@ -107,6 +107,56 @@ test("render page when query parameter is passed", async () => {
   // Wait for the member's name to appear
   const userNameElement = await screen.findByText(mockedMember.name);
   expect(userNameElement).toBeInTheDocument();
+});
+
+describe("Server Error", () => {
+  test("render error UI when data fetching has error", () => {
+    vi.mocked(useMembers).mockReturnValue(
+      mock({
+        isLoading: false,
+        error: new Error("An error occurred"),
+        members: [],
+        totalCohorts: 3,
+        filter: { name: "", cohort: null },
+        setFilter: vi.fn(),
+      }),
+    );
+
+    render(<Progress />);
+
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "오류가 발생했습니다. 문제가 지속된다면 아래 Github Issue를 방문하여 문제를 보고하거나 진행 상황을 확인해 주시면 감사하겠습니다.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("문제 보고하기")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "문제 보고하기" })).toHaveAttribute(
+      "href",
+      "https://github.com/DaleStudy/leaderboard/issues",
+    );
+  });
+
+  test("render empty UI in Sidebar when data fetching has error", () => {
+    vi.mocked(useMembers).mockReturnValue(
+      mock({
+        isLoading: false,
+        error: new Error("An error occurred"),
+        members: [],
+        totalCohorts: 3,
+        filter: { name: "", cohort: null },
+        setFilter: vi.fn(),
+      }),
+    );
+
+    render(<Progress />);
+
+    const sidebar = within(screen.getByRole("complementary"));
+    expect(sidebar.queryByText("풀이 보기")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /리더보드로 돌아가기/i }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 function mockMember({ id = faker.internet.userName() }: { id?: string } = {}) {

--- a/src/pages/Progress/Progress.tsx
+++ b/src/pages/Progress/Progress.tsx
@@ -1,14 +1,15 @@
+import {
+  problemCounts,
+  problemMap,
+  problems,
+} from "../../api/constants/problems";
+import { getMembers } from "../../api/getMembers";
+import useMembers from "../../hooks/useMembers";
+
 import Layout from "../../components/Layout/Layout";
 import Sidebar from "../../components/Sidebar/Sidebar";
 import { Table } from "../../components/Table/Table";
 import NotFound from "../../components/NotFound/NotFound";
-import { getMembers } from "../../api/getMembers";
-import {
-  problems,
-  problemMap,
-  problemCounts,
-} from "../../api/constants/problems";
-import useMembers from "../../hooks/useMembers";
 
 import styles from "./Progress.module.css";
 
@@ -18,7 +19,28 @@ export default function Progress() {
   const memberId = new URL(location.href).searchParams.get("member");
 
   if (isLoading) return <p>Loading...</p>;
-  if (error) return <p>Error!</p>; // TODO replace with a proper error component
+
+  if (error) {
+    return (
+      <Layout>
+        <main className={styles.progress}>
+          <h1>풀이 현황</h1>
+          <div className={styles.container}>
+            <section className={styles.sideBar} aria-labelledby="프로필">
+              <Sidebar isError />
+            </section>
+
+            <section
+              className={styles.problemTableWrapper}
+              aria-labelledby="문제 리스트"
+            >
+              <Table problems={[]} solvedProblems={[]} isError={!!error} />
+            </section>
+          </div>
+        </main>
+      </Layout>
+    );
+  }
 
   const member = members.find((m) => m.id === memberId);
   if (!member) {
@@ -66,22 +88,33 @@ export default function Progress() {
         <h1>풀이 현황</h1>
         <div className={styles.container}>
           <section className={styles.sideBar} aria-labelledby="프로필">
-            <Sidebar
-              githubUsername={member.name}
-              easyProgress={easyProgress}
-              mediumProgress={mediumProgress}
-              hardProgress={hardProgress}
-              solvedProblems={totalSolved}
-              totalProblems={totalProblems}
-              profileUrl={profileUrl}
-              currentCohort={currentCohort}
-              cohorts={cohorts}
-              grade={grade}
-            />
+            {error ? (
+              <Sidebar isError />
+            ) : (
+              <Sidebar
+                githubUsername={member.name}
+                easyProgress={easyProgress}
+                mediumProgress={mediumProgress}
+                hardProgress={hardProgress}
+                solvedProblems={totalSolved}
+                totalProblems={totalProblems}
+                profileUrl={profileUrl}
+                currentCohort={currentCohort}
+                cohorts={cohorts}
+                grade={grade}
+              />
+            )}
           </section>
 
-          <section className={styles.problemList} aria-labelledby="문제 리스트">
-            <Table problems={problems} solvedProblems={member.solvedProblems} />
+          <section
+            className={styles.problemTableWrapper}
+            aria-labelledby="문제 리스트"
+          >
+            <Table
+              problems={problems}
+              solvedProblems={member.solvedProblems}
+              isError={!!error}
+            />
           </section>
         </div>
       </main>


### PR DESCRIPTION
## Notes
- 요구사항에 맞게 에러 UI를 구현하면서 의아했던 점이 많습니다.

- Progress의 경우, 기존 순서대로 서버 에러 UI를 보여주면, 항상 Member Not Found 에러부터 보여주게 되어 서버 에러 UI 렌더링을 컴포넌트 상단으로 끌어올렸습니다. 이런 방식이 어색하지 않은지? 어색하다면 어떤 방식으로 구현하면 좋을지 조언 부탁드립니다.

- EmptySidebar의 경우, 기존 Sidebar에 Empty 또는 Error prop을 전달해서 컴포넌트의 복잡도를 늘리는 것이 효용이 그렇게 까지 없다고 판단했습니다. 그래서 별도로 컴포넌트를 만들었습니다.

## Preview
### Leaderboard
![image](https://github.com/user-attachments/assets/1f427702-c25f-456d-a8c9-2faac6a65588)

### Progress
![image](https://github.com/user-attachments/assets/c3c673f2-bece-4040-a58b-4f9679076f4d)

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?