### PR TITLE
LinkedIn 공유 링크의 member ID 누락 문제 해결

### DIFF
--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -234,6 +234,6 @@ test("render LinkedIn link", () => {
   });
   expect(linkedInLink).toHaveAttribute(
     "href",
-    `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=테스트1&organizationId=104834174&certUrl=${location.href}`,
+    `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=테스트1&organizationId=104834174&certUrl=${encodeURIComponent(location.href)}`,
   );
 });

--- a/src/pages/Certificate/Certificate.tsx
+++ b/src/pages/Certificate/Certificate.tsx
@@ -1,10 +1,10 @@
 import { getMembers } from "../../api/getMembers";
-import useMembers from "../../hooks/useMembers";
 import Signature from "../../assets/signature.png";
+import useMembers from "../../hooks/useMembers";
 
+import Button from "../../components/Button/Button";
 import Layout from "../../components/Layout/Layout";
 import Link from "../../components/Link/Link";
-import Button from "../../components/Button/Button";
 import NotFound from "../../components/NotFound/NotFound";
 
 import styles from "./Certificate.module.css";
@@ -21,6 +21,7 @@ export default function Certificate() {
     ({ id }) =>
       id === new URLSearchParams(document.location.search).get("member"),
   );
+
   if (!member) {
     return (
       <Layout>
@@ -29,7 +30,7 @@ export default function Certificate() {
     );
   }
 
-  const linkedInURL = `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${member.name}&organizationId=104834174&certUrl=${location.href}`;
+  const linkedInURL = `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${member?.name}&organizationId=104834174&certUrl=${encodeURIComponent(location.href)}`;
 
   return (
     <Layout>


### PR DESCRIPTION
LinkedIn 공유 링크의 certUrl 매개변수가 제대로 인코딩되지 않아 URL이 올바르게 해석되지 않는 문제를 해결합니다.

기존에는 location.href를 certUrl 매개변수로 직접 전달했으며, 이로 인해 ?, =, & 등의 특수 문자가 쿼리 구조를 깨뜨려 LinkedIn에서 공유된 URL 일부가 잘렸습니다.

이번 수정에서는 location.href 값에 encodeURIComponent를 적용하여 모든 특수 문자가 올바르게 인코딩되도록 했습니다. 이를 통해 URL이 하나의 쿼리 스트링 값으로 제대로 전달되어 문제를 해결합니다.


## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
