### PR TITLE
Grade의 타입을 Enum에서 Union으로 변경

### DIFF
--- a/src/api/services/process/processService.test.ts
+++ b/src/api/services/process/processService.test.ts
@@ -111,29 +111,29 @@ test("remove member with no submissions", () => {
 });
 
 test.each([
-  [1, Grade.SEED],
-  [2, Grade.SPROUT],
-  [3, Grade.SPROUT],
-  [4, Grade.LEAF],
-  [5, Grade.LEAF],
-  [6, Grade.BRANCH],
-  [7, Grade.BRANCH],
-  [8, Grade.FRUIT],
-  [9, Grade.FRUIT],
-  [10, Grade.TREE],
-  [11, Grade.TREE],
+  [1, "SEED"],
+  [2, "SPROUT"],
+  [3, "SPROUT"],
+  [4, "LEAF"],
+  [5, "LEAF"],
+  [6, "BRANCH"],
+  [7, "BRANCH"],
+  [8, "FRUIT"],
+  [9, "FRUIT"],
+  [10, "TREE"],
+  [11, "TREE"],
 ])(
   "assign grades based on submissions: totalSubmissions: %i, expectedGrade: %s",
   (totalSubmissions, expectedGrade) => {
     // Arrange
     const config: Partial<Config> = {
       gradeThresholds: [
-        [Grade.SEED, 0],
-        [Grade.SPROUT, 2],
-        [Grade.LEAF, 4],
-        [Grade.BRANCH, 6],
-        [Grade.FRUIT, 8],
-        [Grade.TREE, 10],
+        ["SEED", 0],
+        ["SPROUT", 2],
+        ["LEAF", 4],
+        ["BRANCH", 6],
+        ["FRUIT", 8],
+        ["TREE", 10],
       ],
     };
     const processService = createMockProcessService(config);

--- a/src/api/services/process/processService.ts
+++ b/src/api/services/process/processService.ts
@@ -35,7 +35,7 @@ const initializeMemberMap = (
       ...member,
       solvedProblems: [],
       progress: 0,
-      grade: Grade.SEED,
+      grade: "SEED",
     };
   });
 
@@ -104,5 +104,5 @@ const determineGrade = (
     ([, threshold]) => totalSubmissions >= threshold,
   );
 
-  return grade ? grade[0] : Grade.SEED;
+  return grade ? grade[0] : "SEED";
 };

--- a/src/api/services/types.ts
+++ b/src/api/services/types.ts
@@ -1,11 +1,4 @@
-export enum Grade {
-  SEED = "SEED",
-  SPROUT = "SPROUT",
-  LEAF = "LEAF",
-  BRANCH = "BRANCH",
-  FRUIT = "FRUIT",
-  TREE = "TREE",
-}
+export type Grade = "SEED" | "SPROUT" | "LEAF" | "BRANCH" | "FRUIT" | "TREE";
 
 export type MemberIdentity = {
   id: string; // lowercase

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Card from "./Card";
-import { Grade } from "../../api/services/types";
 
 const meta: Meta<typeof Card> = {
   component: Card,
@@ -14,7 +13,7 @@ export default meta;
 export const Seed: StoryObj<typeof Card> = {
   args: {
     name: "seed",
-    grade: Grade.SEED,
+    grade: "SEED",
     cohorts: [1],
   },
 };
@@ -22,7 +21,7 @@ export const Seed: StoryObj<typeof Card> = {
 export const Sprout: StoryObj<typeof Card> = {
   args: {
     name: "sprout",
-    grade: Grade.SPROUT,
+    grade: "SPROUT",
     cohorts: [2],
   },
 };
@@ -30,7 +29,7 @@ export const Sprout: StoryObj<typeof Card> = {
 export const Leaf: StoryObj<typeof Card> = {
   args: {
     name: "leaf",
-    grade: Grade.LEAF,
+    grade: "LEAF",
     cohorts: [3],
   },
 };
@@ -38,7 +37,7 @@ export const Leaf: StoryObj<typeof Card> = {
 export const Branch: StoryObj<typeof Card> = {
   args: {
     name: "branch",
-    grade: Grade.BRANCH,
+    grade: "BRANCH",
     cohorts: [4],
   },
 };
@@ -46,7 +45,7 @@ export const Branch: StoryObj<typeof Card> = {
 export const Fruit: StoryObj<typeof Card> = {
   args: {
     name: "fruit",
-    grade: Grade.FRUIT,
+    grade: "FRUIT",
     cohorts: [5],
   },
 };
@@ -54,7 +53,7 @@ export const Fruit: StoryObj<typeof Card> = {
 export const Tree: StoryObj<typeof Card> = {
   args: {
     name: "tree",
-    grade: Grade.TREE,
+    grade: "TREE",
     cohorts: [6],
   },
 };

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -1,8 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
 import { expect, test } from "vitest";
-
-import { Grade } from "../../api/services/types";
-
 import Card from "./Card";
 
 test("render grade image", () => {
@@ -10,14 +7,14 @@ test("render grade image", () => {
     <Card
       id="test"
       name="test"
-      grade={Grade.TREE}
+      grade={"TREE"}
       currentCohort={1}
       cohorts={[1]}
     />,
   );
 
   expect(
-    screen.getByRole("img", { name: `${Grade.TREE} image` }),
+    screen.getByRole("img", { name: `${"TREE"} image` }),
   ).toBeInTheDocument();
 });
 
@@ -27,7 +24,7 @@ test("render github name", () => {
     <Card
       id="test"
       name={name}
-      grade={Grade.TREE}
+      grade={"TREE"}
       currentCohort={1}
       cohorts={[1]}
     />,
@@ -42,7 +39,7 @@ test("render cohort", () => {
     <Card
       id="test"
       name="user123"
-      grade={Grade.TREE}
+      grade={"TREE"}
       currentCohort={currentCohort}
       cohorts={[currentCohort]}
     />,
@@ -59,7 +56,7 @@ test("render progress link", () => {
     <Card
       id={id}
       name="user123"
-      grade={Grade.TREE}
+      grade={"TREE"}
       currentCohort={1}
       cohorts={[1]}
     />,
@@ -79,7 +76,7 @@ test("render certificate link", () => {
     <Card
       id={id}
       name="user123"
-      grade={Grade.TREE}
+      grade={"TREE"}
       currentCohort={1}
       cohorts={[1]}
     />,

--- a/src/components/GradeImage/GradeImage.stories.tsx
+++ b/src/components/GradeImage/GradeImage.stories.tsx
@@ -1,11 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Card from "./GradeImage";
-import { Grade } from "../../api/services/types";
 
 const meta: Meta<typeof Card> = {
   component: Card,
   args: {
-    grade: Grade.SEED,
+    grade: "SEED",
     width: 105,
     height: 128,
   },
@@ -13,10 +12,4 @@ const meta: Meta<typeof Card> = {
 
 export default meta;
 
-export const Seed: StoryObj<typeof Card> = {
-  args: {
-    grade: Grade.SEED,
-    width: 105,
-    height: 128,
-  },
-};
+export const Default: StoryObj<typeof Card> = {};

--- a/src/components/GradeImage/GradeImage.test.tsx
+++ b/src/components/GradeImage/GradeImage.test.tsx
@@ -2,11 +2,9 @@ import { faker } from "@faker-js/faker";
 import { render, screen } from "@testing-library/react";
 import { expect, test } from "vitest";
 
-import { Grade } from "../../api/services/types";
-
 import GradeImage from "./GradeImage";
 
-test.each(Object.values(Grade))(
+test.each(["SEED", "SPROUT", "LEAF", "BRANCH", "FRUIT", "TREE"] as const)(
   "attach alternative text for %s image",
   (grade) => {
     render(
@@ -24,7 +22,14 @@ test.each(Object.values(Grade))(
 test("set width and height", () => {
   render(
     <GradeImage
-      grade={faker.helpers.arrayElement(Object.values(Grade))}
+      grade={faker.helpers.arrayElement([
+        "SEED",
+        "SPROUT",
+        "LEAF",
+        "BRANCH",
+        "FRUIT",
+        "TREE",
+      ])}
       width={105}
       height={128}
     />,

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Sidebar from "./Sidebar.tsx";
-import { Grade } from "../../api/services/types";
 
 const meta = {
   component: Sidebar,
@@ -14,7 +13,7 @@ const meta = {
     profileUrl: "https://avatars.githubusercontent.com/u/104721736?v=4",
     currentCohort: 3,
     cohorts: [1, 2, 3],
-    grade: Grade.LEAF,
+    grade: "LEAF",
   },
 } satisfies Meta<typeof Sidebar>;
 
@@ -27,7 +26,7 @@ export const Default: StoryObj<typeof meta> = {
     hardProgress: "3/5",
     solvedProblems: 16,
     totalProblems: 25,
-    grade: Grade.LEAF,
+    grade: "LEAF",
     cohorts: [1, 2, 3],
     currentCohort: 3,
     githubUsername: "testuser",
@@ -42,7 +41,7 @@ export const HighProgress: StoryObj<typeof meta> = {
     easyProgress: "10/10",
     mediumProgress: "10/10",
     hardProgress: "8/10",
-    grade: Grade.FRUIT,
+    grade: "FRUIT",
     currentCohort: 3,
     cohorts: [1, 2, 3],
     githubUsername: "testuser",
@@ -57,7 +56,7 @@ export const NoProblems: StoryObj<typeof meta> = {
     hardProgress: "0/0",
     solvedProblems: 0,
     totalProblems: 0,
-    grade: Grade.SEED,
+    grade: "SEED",
     currentCohort: 3,
     cohorts: [1, 2, 3],
     githubUsername: "testuser",

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -1,7 +1,6 @@
 import { test, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import Sidebar from "./Sidebar.tsx";
-import { Grade } from "../../api/services/types";
 
 test("renders Sidebar with all elements", () => {
   render(
@@ -15,7 +14,7 @@ test("renders Sidebar with all elements", () => {
       profileUrl="example.png"
       currentCohort={3}
       cohorts={[1, 2, 3]}
-      grade={Grade.TREE}
+      grade={"TREE"}
     />,
   );
 

--- a/src/hooks/useMembers.test.ts
+++ b/src/hooks/useMembers.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { expect, test, vi } from "vitest";
 import { faker } from "@faker-js/faker";
 
-import { Grade, type Member } from "../api/services/types";
+import { type Member } from "../api/services/types";
 import useMembers from "./useMembers";
 import { problems } from "../api/constants/problems";
 
@@ -15,7 +15,14 @@ function createMockMember(custom: Partial<Member> = {}): Member {
     cohorts: [currentCohort],
     profileUrl: faker.internet.url(),
     progress: faker.number.int({ min: 0, max: 100 }),
-    grade: faker.helpers.arrayElement(Object.values(Grade)),
+    grade: faker.helpers.arrayElement([
+      "SEED",
+      "SPROUT",
+      "LEAF",
+      "BRANCH",
+      "FRUIT",
+      "TREE",
+    ]),
     solvedProblems: faker.helpers.arrayElements(
       problems,
       faker.number.int({ min: 0, max: 5 }),

--- a/src/pages/Leaderboard/Leaderboard.test.tsx
+++ b/src/pages/Leaderboard/Leaderboard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { type Member, Grade } from "../../api/services/types";
+import { type Member } from "../../api/services/types";
 import useMembers from "../../hooks/useMembers";
 import Leaderboard from "./Leaderboard";
 
@@ -139,6 +139,13 @@ function mockMember() {
     name: userName,
     currentCohort,
     cohorts: [currentCohort],
-    grade: faker.helpers.arrayElement(Object.values(Grade)),
+    grade: faker.helpers.arrayElement([
+      "SEED",
+      "SPROUT",
+      "LEAF",
+      "BRANCH",
+      "FRUIT",
+      "TREE",
+    ]),
   });
 }

--- a/src/pages/Progress/Progress.test.tsx
+++ b/src/pages/Progress/Progress.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { type Member, Grade } from "../../api/services/types";
+import { type Member } from "../../api/services/types";
 import useMembers from "../../hooks/useMembers";
 import Progress from "./Progress";
 
@@ -166,7 +166,14 @@ function mockMember({ id = faker.internet.username() }: { id?: string } = {}) {
     name: id,
     currentCohort,
     cohorts: [currentCohort],
-    grade: faker.helpers.arrayElement(Object.values(Grade)),
+    grade: faker.helpers.arrayElement([
+      "SEED",
+      "SPROUT",
+      "LEAF",
+      "BRANCH",
+      "FRUIT",
+      "TREE",
+    ]),
     profileUrl: faker.internet.url(),
     solvedProblems: [],
   });


### PR DESCRIPTION
스토리북이 Enum에 대한 컨트롤 타입을 제대로 추론하지 못하는 이슈를 해결하기 위해서 Grade의 타입을 Enum에서 Union으로 변경하는 것을 본 PR을 통해 제안드리고 싶습니다. @Sunjae95 님께서 https://github.com/DaleStudy/leaderboard/pull/151#discussion_r1894793169 에서 의견을 주셨던 것처럼 스토리에 추가적으로 `argTypes`을 설정할 수도 있지만 그럴 경우 스토리들의 컨트롤 타입이 컴포넌트 함수의 입력 타입과 달라질 가능성이 생겨서 유지보수 측면에서 효과적이지 않거든요. 애초에 타입스크립트로 코드를 짜는 의미가 퇴색되는 측면도 있고요.

프로젝트에서 비슷한 용도로 사용되는 `Difficulty`의 타입은 String Literal Union으로 되어 있더라고요. 이 것은 아직 팀 차원에서 언제 Enum을 쓰고 언제 String Literal Union을 사용할지에 대한 컨벤션이 정립되지 않았다는 것을 보여주는 예라는 생각이 들었습니다!

https://github.com/DaleStudy/leaderboard/blob/e5f777adfb46ec0adda2ee608badca7f2a626f12/src/api/services/types.ts#L24

다른 프로그래밍 언어와 달리 타입스크립트에서 Enum을 쓰는 것에 대해서는 사실 논쟁의 여지가 상당한데, 저는 개인적으로 꼭 Enum을 써야하는 명확한 근거가 있지 않은 이상은 String Literal Union을 사용하려고 노력하고 있습니다. Enum을 쓰다보면 비단 스토리북 뿐만 아니라 다른 라이브러리와도 자질구질한 이슈에 부딪혀서 스트레스를 받은 적이 너무 많거든요... 😩

타입스크립트의 Enum 논쟁에 대해서 생소하시다면 [이 글](https://www.typescriptcourse.com/string-literal-unions-over-enums)을 한 번 읽어보시기를 추천드립니다. 그나마 가장 객관적으로 Enum 옹호자와 비난자의 논점들을 다루고 있거든요. (우리는 프로젝트를 끝내야 하니 이 논쟁에 너무 빨려 들어가지 않았으면 좋겠습니다 ㅋㅋ 😛)

## 체크리스트

- [x] 이슈가 연결되어 있나요? fix #157 
- [x] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
