### PR TITLE
수료증 페이지에 리더보드로 돌아가기 버튼 추가

### DIFF
--- a/src/pages/Certificate/Certificate.module.css
+++ b/src/pages/Certificate/Certificate.module.css
@@ -106,14 +106,17 @@
   margin-top: 15px;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  column-gap: 15px;
-  color: var(--bg-100);
+  justify-content: space-between;
 
-  & > a {
+  & a {
     max-height: 60px;
     height: 60px;
     font-size: 20px;
+  }
+
+  & > div {
+    display: flex;
+    column-gap: 15px;
   }
 }
 

--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -173,6 +173,27 @@ test("render content solved problems, cohort", () => {
   });
 });
 
+test("render learderboard link", () => {
+  vi.mocked(useMembers).mockReturnValue(
+    mock({
+      isLoading: false,
+      error: null,
+      members: [mock<Member>({ id: "test1", name: "테스트1" })],
+      totalCohorts: 0,
+      filter: { name: "", cohort: null },
+      setFilter: vi.fn(),
+    }),
+  );
+
+  location.href = new URL(`?member=test1`, location.href).toString();
+  render(<Certificate />);
+
+  const leaderboardLink = screen.getByRole("link", {
+    name: "리더보드로 돌아가기",
+  });
+  expect(leaderboardLink).toHaveAttribute("href", `/`);
+});
+
 test("render print button", () => {
   vi.mocked(useMembers).mockReturnValue(
     mock({

--- a/src/pages/Certificate/Certificate.tsx
+++ b/src/pages/Certificate/Certificate.tsx
@@ -101,17 +101,23 @@ export default function Certificate() {
             </section>
 
             <section className={styles.buttons}>
-              <Button
-                variant="primary"
-                size="large"
-                onClick={() => window.print()}
-              >
-                출력
-              </Button>
-
-              <Link variant="primaryButton" href={linkedInURL}>
-                링크드인 공유
+              <Link variant="secondaryButton" href="/">
+                리더보드로 돌아가기
               </Link>
+
+              <div>
+                <Button
+                  variant="primary"
+                  size="large"
+                  onClick={() => window.print()}
+                >
+                  출력
+                </Button>
+
+                <Link variant="primaryButton" href={linkedInURL}>
+                  링크드인 공유
+                </Link>
+              </div>
             </section>
           </div>
         </section>

--- a/src/pages/Leaderboard/Leaderboard.stories.tsx
+++ b/src/pages/Leaderboard/Leaderboard.stories.tsx
@@ -117,7 +117,7 @@ export const ByMember: StoryObj<typeof meta> = {
         () => {
           expect(canvas.getAllByRole("article")).toHaveLength(3);
         },
-        { timeout: 20_000 },
+        { timeout: 15_000 },
       );
     });
 
@@ -127,7 +127,7 @@ export const ByMember: StoryObj<typeof meta> = {
         () => {
           expect(canvas.getAllByRole("article")).toHaveLength(1);
         },
-        { timeout: 20_000 },
+        { timeout: 15_000 },
       );
     });
   },


### PR DESCRIPTION
## 미리보기
![image](https://github.com/user-attachments/assets/455829e2-51aa-4dae-9071-705fa4575068)

수료증 페이지에 리더보드로 가는 링크 버튼을 추가했습니다.
링크버튼을 추가하면서 이미 방문했을 때 링크버튼 색상이 동일하게 나오지 않아 https://github.com/DaleStudy/leaderboard/issues/161 여기서 수정할 예정입니다. 감안하여 확인부탁드립니다!

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
