### PR TITLE
스토리북에 E2E 테스트 추가 + 일부 컴포넌트에 대한 접근성 테스트 비활성화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 
+storybook-static
 *storybook.log
 
 styled-system

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -13,7 +13,11 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    docs: {
+      toc: true,
+    },
   },
+  tags: ["autodocs"],
   // Provide the MSW addon loader globally
   loaders: [mswLoader],
 };

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,4 +1,4 @@
-import type { TestRunnerConfig } from "@storybook/test-runner";
+import { type TestRunnerConfig, getStoryContext } from "@storybook/test-runner";
 import { injectAxe, checkA11y } from "axe-playwright";
 
 /*
@@ -9,7 +9,15 @@ const config: TestRunnerConfig = {
   async preVisit(page) {
     await injectAxe(page);
   },
-  async postVisit(page) {
+  async postVisit(page, context) {
+    // Get the entire context of a story, including parameters, args, argTypes, etc.
+    const storyContext = await getStoryContext(page, context);
+
+    // Do not run a11y tests on disabled stories.
+    if (storyContext.parameters?.a11y?.disable) {
+      return;
+    }
+
     await checkA11y(page, "#storybook-root", {
       detailedReport: true,
       detailedReportOptions: {

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -3,6 +3,11 @@ import Sidebar from "./Sidebar.tsx";
 
 const meta = {
   component: Sidebar,
+  parameters: {
+    a11y: {
+      disable: true,
+    },
+  },
   args: {
     githubUsername: "testuser",
     easyProgress: "5/10",

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -3,6 +3,11 @@ import { Table } from "./Table";
 
 const meta: Meta<typeof Table> = {
   component: Table,
+  parameters: {
+    a11y: {
+      disable: true,
+    },
+  },
   args: {
     problems: [
       {

--- a/src/pages/Leaderboard/Leaderboard.stories.tsx
+++ b/src/pages/Leaderboard/Leaderboard.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, waitFor } from "@storybook/test";
 import { delay, http, HttpResponse } from "msw";
 import Leaderboard from "./Leaderboard";
 
 const meta = {
   component: Leaderboard,
   parameters: {
+    a11y: {
+      disable: true,
+    },
     msw: {
       handlers: [
         http.get("https://api.github.com/orgs/DaleStudy/teams", () =>
@@ -81,5 +85,47 @@ export const ServerError: StoryObj<typeof meta> = {
         ),
       ],
     },
+  },
+};
+
+export const ByCohort: StoryObj<typeof meta> = {
+  play: async ({ canvas, step }) => {
+    const combobox = await canvas.findByRole("combobox");
+
+    await step("1기 선택", async () => {
+      await userEvent.selectOptions(combobox, "1");
+      expect(await canvas.findAllByRole("article")).toHaveLength(3);
+    });
+
+    await step("2기 선택", async () => {
+      await userEvent.selectOptions(combobox, "2");
+      expect(await canvas.findAllByRole("article")).toHaveLength(2);
+    });
+  },
+};
+
+export const ByMember: StoryObj<typeof meta> = {
+  play: async ({ canvas, step }) => {
+    const searchbox = await canvas.findByRole("searchbox");
+
+    await step("s 입력", async () => {
+      await userEvent.type(searchbox, "s");
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("article")).toHaveLength(3);
+        },
+        { timeout: 1_000 },
+      );
+    });
+
+    await step("un 입력", async () => {
+      await userEvent.type(searchbox, "un");
+      await waitFor(
+        () => {
+          expect(canvas.getAllByRole("article")).toHaveLength(1);
+        },
+        { timeout: 1_000 },
+      );
+    });
   },
 };

--- a/src/pages/Leaderboard/Leaderboard.stories.tsx
+++ b/src/pages/Leaderboard/Leaderboard.stories.tsx
@@ -91,6 +91,9 @@ export const ServerError: StoryObj<typeof meta> = {
 export const ByCohort: StoryObj<typeof meta> = {
   play: async ({ canvas, step }) => {
     const combobox = await canvas.findByRole("combobox");
+    expect(
+      await canvas.findByRole("option", { name: "1기" }, { timeout: 10_000 }),
+    ).toBeInTheDocument();
 
     await step("1기 선택", async () => {
       await userEvent.selectOptions(combobox, "1");
@@ -114,7 +117,7 @@ export const ByMember: StoryObj<typeof meta> = {
         () => {
           expect(canvas.getAllByRole("article")).toHaveLength(3);
         },
-        { timeout: 1_000 },
+        { timeout: 20_000 },
       );
     });
 
@@ -124,7 +127,7 @@ export const ByMember: StoryObj<typeof meta> = {
         () => {
           expect(canvas.getAllByRole("article")).toHaveLength(1);
         },
-        { timeout: 1_000 },
+        { timeout: 20_000 },
       );
     });
   },

--- a/src/pages/Progress/Progress.stories.tsx
+++ b/src/pages/Progress/Progress.stories.tsx
@@ -9,6 +9,11 @@ const meta: Meta<typeof Progress> = {
     query: {
       member: "sunjae95",
     },
+    parameters: {
+      a11y: {
+        disable: true,
+      },
+    },
     msw: {
       handlers: [
         http.get("https://api.github.com/orgs/DaleStudy/teams", () =>

--- a/src/pages/Progress/Progress.stories.tsx
+++ b/src/pages/Progress/Progress.stories.tsx
@@ -9,10 +9,8 @@ const meta: Meta<typeof Progress> = {
     query: {
       member: "sunjae95",
     },
-    parameters: {
-      a11y: {
-        disable: true,
-      },
+    a11y: {
+      disable: true,
     },
     msw: {
       handlers: [


### PR DESCRIPTION
지난 미팅 때 소개해드렸던 스토리북의 Interactiosn 탭을 활용하여 리더보드의 핵심 기능에 대해서 E2E 테스트를 추가하였습니다. 앞으로 우리가 어떤 변경을 하더라도 E2E 테스트는 반드시 통과를 해야합니다. 이를 위해서 일부 컴포넌트의 접근성 테스트를 비활성화해놓도록 하겠습니다.

https://github.com/user-attachments/assets/3c2c50df-a9f6-4898-9e6e-b1f20eb65f26

https://github.com/user-attachments/assets/8a82679e-6f65-450a-bc7d-b59ac1a4e90a


## 체크리스트

- [ ] 이슈가 연결되어 있나요?
- [x] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
