### PR TITLE
feat: 수료증 연동 시 제목 변경

### DIFF
--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -6,6 +6,7 @@ import { mock } from "vitest-mock-extended";
 import { Member } from "../../api/services/types";
 import useMembers from "../../hooks/useMembers";
 import Certificate from "./Certificate";
+import { gradeEmojiMap } from "./constants";
 
 vi.mock("../../hooks/useMembers");
 
@@ -240,7 +241,7 @@ test("render LinkedIn link", () => {
     mock({
       isLoading: false,
       error: null,
-      members: [mock<Member>({ id: "test1", name: "테스트1" })],
+      members: [mock<Member>({ id: "test1", name: "테스트1", grade: "SEED" })],
       totalCohorts: 0,
       filter: { name: "", cohort: null },
       setFilter: vi.fn(),
@@ -253,10 +254,18 @@ test("render LinkedIn link", () => {
   const linkedInLink = screen.getByRole("link", {
     name: "링크드인 공유",
   });
-  expect(linkedInLink).toHaveAttribute(
-    "href",
-    `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=테스트1&organizationId=104834174&certUrl=${encodeURIComponent(location.href)}`,
-  );
+
+  const certificateName = `Leetcode 75 ${gradeEmojiMap["SEED"]}`;
+  const params = new URLSearchParams({
+    startTask: "CERTIFICATION_NAME",
+    name: certificateName,
+    organizationId: "104834174",
+    certUrl: location.href,
+  });
+
+  const expectedLinkedInURL = `https://www.linkedin.com/profile/add?${params.toString()}`;
+
+  expect(linkedInLink).toHaveAttribute("href", expectedLinkedInURL);
 });
 
 test("render the error message while fetching members", () => {

--- a/src/pages/Certificate/Certificate.tsx
+++ b/src/pages/Certificate/Certificate.tsx
@@ -7,9 +7,10 @@ import Layout from "../../components/Layout/Layout";
 import Link from "../../components/Link/Link";
 import NotFound from "../../components/NotFound/NotFound";
 import Spinner from "../../components/Spinner/Spinner";
+import ServerError from "../../components/ServerError/ServerError";
 
 import styles from "./Certificate.module.css";
-import ServerError from "../../components/ServerError/ServerError";
+import { gradeEmojiMap } from "./constants";
 
 const cohortSuffix = ["th", "st", "nd", "rd"];
 
@@ -54,7 +55,16 @@ export default function Certificate() {
     );
   }
 
-  const linkedInURL = `https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${member?.name}&organizationId=104834174&certUrl=${encodeURIComponent(location.href)}`;
+  const certificateName = `Leetcode 75 ${gradeEmojiMap[member.grade]}`;
+
+  const params = new URLSearchParams({
+    startTask: "CERTIFICATION_NAME",
+    name: certificateName,
+    organizationId: "104834174",
+    certUrl: location.href,
+  });
+
+  const linkedInURL = `https://www.linkedin.com/profile/add?${params.toString()}`;
 
   return (
     <Layout>

--- a/src/pages/Certificate/constants.ts
+++ b/src/pages/Certificate/constants.ts
@@ -1,0 +1,10 @@
+import type { Grade } from "../../api/services/types";
+
+export const gradeEmojiMap: Record<Grade, string> = {
+  SEED: "🌱",
+  SPROUT: "🌿",
+  LEAF: "🍃",
+  BRANCH: "🌳",
+  FRUIT: "🍎",
+  TREE: "🌲",
+};


### PR DESCRIPTION
- 원래 깃허브 유저네임이 나오던 것을 Leetcode 75 {Grade} 식으로 변경한다.

## 체크리스트

- [ ] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
