### PR TITLE
방문한 링크버튼 텍스트 색상 변하지 않도록 수정

### DIFF
--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -6,6 +6,7 @@
 
 .text {
   padding: 7px 5px;
+  color: var(--text-900);
 
   &:hover {
     font-weight: var(--font-weight-bold);
@@ -13,6 +14,10 @@
 
   &:active {
     color: var(--bg-400);
+  }
+
+  &:visited {
+    color: var(--text-900);
   }
 }
 
@@ -37,6 +42,10 @@
     background-color: var(--bg-400);
     text-decoration: underline;
     font-weight: var(--font-weight-bold);
+  }
+
+  &:visited {
+    color: var(--bg-100);
   }
 }
 
@@ -63,5 +72,9 @@
     background-color: #fff;
     text-decoration: underline;
     font-weight: var(--font-weight-bold);
+  }
+
+  &:visited {
+    color: var(--bg-400);
   }
 }


### PR DESCRIPTION
## Primary Button 
### 수정전
![image](https://github.com/user-attachments/assets/ea8542e3-a8ad-4447-94f2-fcb7f4f8a7a8)

### 수정후
![image](https://github.com/user-attachments/assets/f1cae6d9-9c38-4c8e-8612-13ac81beb75a)


## Secondary Button
### 수정전
![image](https://github.com/user-attachments/assets/2f7cc348-338e-450c-86c2-965997aba539)

### 수정후
![image](https://github.com/user-attachments/assets/2a0e1a26-4ff1-4523-af30-9b406c82f849)

Visited color를 지정하지 않아 방문한 곳은 색상이 다르게 나타나는점을 수정했습니다.
## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
