### PR TITLE
Progress 페이지에서 Sidebar가 Header 위에 쌓이는 현상

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -9,6 +9,7 @@
   width: 100%;
   border-bottom: 1px solid var(--bg-300);
   background-color: var(--bg-200);
+  z-index: var(--z-index-header);
 
   header {
     display: flex;

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -1,6 +1,7 @@
 aside {
   position: sticky;
   top: 87px;
+  z-index: var(--z-index-aside);
 }
 
 .cohort {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -2,6 +2,7 @@ aside {
   position: sticky;
   top: 87px;
   z-index: var(--z-index-aside);
+  max-width: 203px;
 }
 
 .cohort {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -1,10 +1,6 @@
 aside {
   position: sticky;
   top: 87px;
-  width: 260px;
-  height: calc(100vh - 40px);
-  overflow-y: auto;
-  align-items: center;
 }
 
 .cohort {
@@ -13,9 +9,6 @@ aside {
 }
 
 .container {
-  top: 230px;
-  left: 20px;
-  width: 250px;
   padding: 20px 35px;
   background-color: var(--bg-200);
   border-radius: 10px;

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import Sidebar from "./Sidebar.tsx";
 
 const meta = {
@@ -8,11 +8,6 @@ const meta = {
       disable: true,
     },
   },
-  decorators: (Story: StoryFn) => (
-    <div style={{ width: "203px" }}>
-      <Story />
-    </div>
-  ),
   args: {
     githubUsername: "testuser",
     easyProgress: "5/10",

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryFn, StoryObj } from "@storybook/react";
 import Sidebar from "./Sidebar.tsx";
 
 const meta = {
@@ -8,6 +8,11 @@ const meta = {
       disable: true,
     },
   },
+  decorators: (Story: StoryFn) => (
+    <div style={{ width: "203px" }}>
+      <Story />
+    </div>
+  ),
   args: {
     githubUsername: "testuser",
     easyProgress: "5/10",

--- a/src/index.css
+++ b/src/index.css
@@ -7,10 +7,14 @@
   --bg-300: #eee8fe;
   --bg-400: #5333e1;
   --text-900: #160b46;
+
   --font-weight-light: 300;
   --font-weight-regular: 400;
   --font-weight-medium: 500;
   --font-weight-bold: 700;
+
+  --z-index-header: 100;
+  --z-index-aside: 10;
 }
 
 * {

--- a/src/pages/Progress/Progress.module.css
+++ b/src/pages/Progress/Progress.module.css
@@ -17,7 +17,7 @@ h1 {
 }
 
 .sideBar {
-  width: 20%;
+  width: 30%;
 }
 
 .problemTableWrapper {


### PR DESCRIPTION
https://github.com/DaleStudy/leaderboard/pull/125#discussion_r1883053996 이 맥락을 보고 z-index를 사용하지 않으려 했지만 별도의 방법이나 저희가 원하는 UI reference를 참고하지 못하여 떠오르지 z-index를 사용했습니다.
z-index가 전역으로 미치는것을 고려한다면 각각의 z-index를 설정하는것보단 z-index값을 root에서 관리하는건 어떨까하여 코드를 수정해서 올려봅니다. 

https://github.com/user-attachments/assets/0042f981-4e97-4f68-b467-9723ffaea2df

추가로 sidebar관련 스타일 불필요하거나 수정되어야하는 부분을 수정했습니다.

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
