### PR TITLE
type 키워드 빠진 곳 일괄 수정 및 관련 TypeScript 설정 변경

### DIFF
--- a/src/api/infra/gitHub/gitHubClient.test.ts
+++ b/src/api/infra/gitHub/gitHubClient.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, beforeEach, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 import { createGitHubClient } from "./gitHubClient";
-import { GitHubMember, GitHubTeam, GitHubTree } from "./types";
+import type { GitHubMember, GitHubTeam, GitHubTree } from "./types";
 
 // Mock data
 const mockGitHubTeams = mock<GitHubTeam[]>();

--- a/src/api/services/fetch/fetchService.test.ts
+++ b/src/api/services/fetch/fetchService.test.ts
@@ -2,8 +2,12 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 import { createGitHubClient } from "../../infra/gitHub/gitHubClient";
 import { createFetchService } from "./fetchService";
-import { Grade } from "../types";
-import { GitHubMember, GitHubTeam, GitHubTree } from "../../infra/gitHub/types";
+import type { Grade } from "../types";
+import type {
+  GitHubMember,
+  GitHubTeam,
+  GitHubTree,
+} from "../../infra/gitHub/types";
 
 // Mock data
 const dummyConfig = {

--- a/src/api/services/process/processService.test.ts
+++ b/src/api/services/process/processService.test.ts
@@ -4,7 +4,7 @@ import { mock } from "vitest-mock-extended";
 
 import { problems } from "../../constants/problems";
 import type { Config } from "../../config/types";
-import { Grade, MemberIdentity, Submission } from "../types";
+import type { Grade, MemberIdentity, Submission } from "../types";
 import { createProcessService } from "./processService";
 
 // Mock data

--- a/src/api/services/process/processService.ts
+++ b/src/api/services/process/processService.ts
@@ -1,11 +1,6 @@
 import { problemMap } from "../../constants/problems";
 import type { Config } from "../../config/types";
-import {
-  Grade,
-  type Member,
-  type MemberIdentity,
-  type Submission,
-} from "../types";
+import type { Grade, Member, MemberIdentity, Submission } from "../types";
 
 export function createProcessService(config: Config) {
   return {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import { Grade } from "../../api/services/types";
+import type { Grade } from "../../api/services/types";
 import GradeImage from "../GradeImage/GradeImage";
 import Link from "../Link/Link";
 import styles from "./Card.module.css";

--- a/src/components/GradeImage/GradeImage.tsx
+++ b/src/components/GradeImage/GradeImage.tsx
@@ -1,4 +1,4 @@
-import { Grade } from "../../api/services/types";
+import type { Grade } from "../../api/services/types";
 import SeedImage from "../../assets/GradeSeed.png";
 import SproutImage from "../../assets/GradeSprout.png";
 import LeafImage from "../../assets/GradeLeaf.png";

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Grade } from "../../api/services/types";
+import type { Grade } from "../../api/services/types";
 import Github from "../../assets/Github.png";
 import GradeImage from "../GradeImage/GradeImage";
 import styles from "./Sidebar.module.css";

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "react";
+import type { HTMLAttributes } from "react";
 import styles from "./Spinner.module.css";
 
 export default function Spinner(props: HTMLAttributes<SVGElement>) {

--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterAll, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { Member } from "../../api/services/types";
+import type { Member } from "../../api/services/types";
 import useMembers from "../../hooks/useMembers";
 import Certificate from "./Certificate";
 import { gradeEmojiMap } from "./constants";

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true
   },
   "include": [
     "src",


### PR DESCRIPTION
예전에 https://github.com/DaleStudy/leaderboard/pull/28#discussion_r1823594152 에서 말씀드렸던 것처럼 타입이나 인터페이스를 불러올 때는 type 키워드를 사용해야합니다. 하지만 import 문을 신경써서 보지 않으면 코드 작성자나 리뷰어 모두 놓치기 쉬운 부분인 것 같습니다. 코드 베이스에서 type 키워드가 빠진 곳을 찾아서 일괄로 수정하였으며, 이 문제를 효과적으로 방지하기 위해서 TypeScript 설정의 `verbatimModuleSyntax` 옵션을 활성화시켰습니다. 앞으로 type 키워드를 누락한 경우 컴파일 오류가 발생해서 프로젝트 빌드가 불가능할 것입니다. 물론 VSCode에서도 코드 아래에 빨간줄이 그어질 것입니다.

![Shot 2025-01-01 at 15 23 11](https://github.com/user-attachments/assets/9383758a-bfca-4b14-9bcd-62f46b081e57)

## 체크리스트

- [ ] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
