### PR TITLE
색깔 접근성 문제 해결 및 스토리북 접근성 테스트 비활성화 해제

### DIFF
--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { expect, test } from "vitest";
 import Card from "./Card";
 
@@ -10,11 +10,13 @@ test("render grade image", () => {
   ).toBeInTheDocument();
 });
 
-test("render github name", () => {
+test("renders GitHub name", () => {
   const name = "user123";
-  render(<Card id="test" name={name} grade={"TREE"} cohorts={[1]} />);
+  render(<Card id="test" name={name} grade="TREE" cohorts={[1]} />);
 
-  expect(screen.getByRole("region", { name })).toBeInTheDocument();
+  const displayedName = screen.getByText(name);
+
+  expect(displayedName).toBeInTheDocument();
 });
 
 test("render cohort", () => {
@@ -27,9 +29,7 @@ test("render progress link", () => {
   const id = "test";
   render(<Card id={id} name="user123" grade={"TREE"} cohorts={[1]} />);
 
-  const link = within(
-    screen.getByRole("region", { name: `카드-네비게이션-${id}` }),
-  ).getByRole("link", { name: "풀이 현황" });
+  const link = screen.getByRole("link", { name: "풀이 현황" });
 
   expect(link).toBeInTheDocument();
   expect(link).toHaveAttribute("href", `/progress?member=${id}`);
@@ -39,9 +39,8 @@ test("render certificate link", () => {
   const id = "test";
   render(<Card id={id} name="user123" grade={"TREE"} cohorts={[1]} />);
 
-  const link = within(
-    screen.getByRole("region", { name: `카드-네비게이션-${id}` }),
-  ).getByRole("link", { name: "수료증" });
+  const link = screen.getByRole("link", { name: "수료증" });
+
   expect(link).toBeInTheDocument();
   expect(link).toHaveAttribute("href", `/certificate?member=${id}`);
 });

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -20,10 +20,7 @@ test("render github name", () => {
 test("render cohort", () => {
   const cohorts = [2];
   render(<Card id="test" name="user123" grade={"TREE"} cohorts={cohorts} />);
-
-  expect(
-    screen.getByRole("region", { name: `${cohorts.at(-1)}기` }),
-  ).toBeInTheDocument();
+  expect(screen.getByText(`${cohorts.at(-1)}기`)).toBeInTheDocument();
 });
 
 test("render progress link", () => {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -13,12 +13,12 @@ interface CardProps {
 export default function Card({ id, name, cohorts, grade }: CardProps) {
   const cohortString = cohorts.join(", ");
   return (
-    <article className={styles.item}>
+    <article className={styles.item} aria-label={`${name}의 카드`}>
       <GradeImage grade={grade} width={105} height={128} />
 
       <section className={styles.content}>
         <div className={styles.nameCohortWrapper}>
-          <section aria-label={name}>
+          <section>
             <div className={styles.iconWrapper}>
               <img src="/github-icon-in-card.svg" alt="깃허브 아이콘" />
             </div>
@@ -33,7 +33,7 @@ export default function Card({ id, name, cohorts, grade }: CardProps) {
           </section>
         </div>
 
-        <section className={styles.links} aria-label={`카드-네비게이션-${id}`}>
+        <section className={styles.links}>
           <Link href={`/progress?member=${id}`} variant="primaryButton">
             풀이 현황
           </Link>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -25,7 +25,7 @@ export default function Card({ id, name, cohorts, grade }: CardProps) {
             <span>{name}</span>
           </section>
 
-          <section aria-label={`${cohortString}기`}>
+          <section>
             <div className={styles.iconWrapper}>
               <img src="/flag-icon.svg" alt="깃발 아이콘" />
             </div>

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -146,7 +146,7 @@ aside {
 }
 
 .hard {
-  color: #e0284b;
+  color: #db2749;
 }
 
 .gradientText {

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -1,6 +1,7 @@
-aside {
+.sidebar {
   display: flex;
   flex-direction: column-reverse;
+
   @media (min-width: 1080px) {
     position: sticky;
     z-index: var(--z-index-aside);

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -3,11 +3,6 @@ import Sidebar from "./Sidebar.tsx";
 
 const meta = {
   component: Sidebar,
-  parameters: {
-    a11y: {
-      disable: true,
-    },
-  },
   args: {
     githubUsername: "testuser",
     easyProgress: "5/10",

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -17,13 +17,13 @@ test("renders Sidebar with all elements", () => {
     />,
   );
 
-  // Check if the sidebar exists
-  const sidebar = screen.getByRole("complementary");
-  expect(sidebar).toBeInTheDocument();
-
-  // Check if the username is displayed
+  // Check if the sidebar exists by unique text (e.g., username)
   const username = screen.getByText(/testuser/i);
   expect(username).toBeInTheDocument();
+
+  // Check if the cohort info is displayed
+  const cohortText = screen.getByText(/1, 2, 3/i);
+  expect(cohortText).toBeInTheDocument();
 
   // Check if the button link exists
   const buttonLink = screen.getByRole("link", {
@@ -35,9 +35,7 @@ test("renders Sidebar with all elements", () => {
 test("renders empty Sidebar when error", () => {
   render(<Sidebar isError />);
 
-  const sidebar = screen.getByRole("complementary");
-  expect(sidebar).toBeInTheDocument();
-
+  // Check that no links are rendered in the error state
   expect(
     screen.queryByRole("link", {
       name: /풀이 보기/i,

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -65,7 +65,7 @@ export default function Sidebar(props: SidebarProps) {
   const cohortString = cohorts.join(", ");
 
   return (
-    <aside>
+    <aside aria-label="Sidebar">
       <div className={styles.container} ref={progressContainerRef}>
         <span className={styles.cohort}>{cohortString}기</span>
         <section className={styles.profile}>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -40,9 +40,9 @@ export default function Sidebar(props: SidebarProps) {
 
   if (props.isError) {
     return (
-      <aside>
+      <div className={styles.sidebar}>
         <div className={`${styles.container} ${styles.error}`}></div>
-      </aside>
+      </div>
     );
   }
 
@@ -65,7 +65,7 @@ export default function Sidebar(props: SidebarProps) {
   const cohortString = cohorts.join(", ");
 
   return (
-    <aside aria-label="Sidebar">
+    <div className={styles.sidebar}>
       <div className={styles.container} ref={progressContainerRef}>
         <span className={styles.cohort}>{cohortString}기</span>
         <section className={styles.profile}>
@@ -110,6 +110,6 @@ export default function Sidebar(props: SidebarProps) {
       <a href="../" className={styles.returnButtonLink}>
         리더보드로 돌아가기
       </a>
-    </aside>
+    </div>
   );
 }

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -66,7 +66,7 @@ tr:nth-child(even) {
 }
 
 .hard {
-  color: #e0284b;
+  color: #db2749;
 }
 
 .completedIcon {

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -3,11 +3,6 @@ import { Table } from "./Table";
 
 const meta: Meta<typeof Table> = {
   component: Table,
-  parameters: {
-    a11y: {
-      disable: true,
-    },
-  },
   args: {
     problems: [
       {

--- a/src/pages/Leaderboard/Leaderboard.stories.tsx
+++ b/src/pages/Leaderboard/Leaderboard.stories.tsx
@@ -6,9 +6,6 @@ import Leaderboard from "./Leaderboard";
 const meta = {
   component: Leaderboard,
   parameters: {
-    a11y: {
-      disable: true,
-    },
     msw: {
       handlers: [
         http.get("https://api.github.com/orgs/DaleStudy/teams", () =>

--- a/src/pages/Progress/Progress.stories.tsx
+++ b/src/pages/Progress/Progress.stories.tsx
@@ -9,9 +9,6 @@ const meta: Meta<typeof Progress> = {
     query: {
       member: "sunjae95",
     },
-    a11y: {
-      disable: true,
-    },
     msw: {
       handlers: [
         http.get("https://api.github.com/orgs/DaleStudy/teams", () =>

--- a/src/pages/Progress/Progress.test.tsx
+++ b/src/pages/Progress/Progress.test.tsx
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -137,7 +137,7 @@ describe("Server Error", () => {
     );
   });
 
-  test("render empty UI in Sidebar when data fetching has error", () => {
+  test("renders empty UI in Sidebar when data fetching has error", () => {
     vi.mocked(useMembers).mockReturnValue(
       mock({
         isLoading: false,
@@ -151,8 +151,10 @@ describe("Server Error", () => {
 
     render(<Progress />);
 
-    const sidebar = within(screen.getByRole("complementary"));
-    expect(sidebar.queryByText("풀이 보기")).not.toBeInTheDocument();
+    // Check if the "풀이 보기" text is not present in the sidebar
+    expect(screen.queryByText("풀이 보기")).not.toBeInTheDocument();
+
+    // Check if the "리더보드로 돌아가기" link is not present in the sidebar
     expect(
       screen.queryByRole("link", { name: /리더보드로 돌아가기/i }),
     ).not.toBeInTheDocument();

--- a/src/pages/Progress/Progress.tsx
+++ b/src/pages/Progress/Progress.tsx
@@ -94,7 +94,7 @@ export default function Progress() {
       <main className={styles.progress}>
         <h1>풀이 현황</h1>
         <div className={styles.container}>
-          <section className={styles.sideBar} aria-labelledby="프로필">
+          <section className={styles.sideBar}>
             {error ? (
               <Sidebar isError />
             ) : (

--- a/src/pages/Progress/Progress.tsx
+++ b/src/pages/Progress/Progress.tsx
@@ -33,7 +33,7 @@ export default function Progress() {
         <main className={styles.progress}>
           <h1>풀이 현황</h1>
           <div className={styles.container}>
-            <section className={styles.sideBar} aria-labelledby="프로필">
+            <section className={styles.sideBar}>
               <Sidebar isError />
             </section>
 


### PR DESCRIPTION
## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?

## 요약
더 이상 접근성 테스트를 비활성화 할 일이 없으므로 disabled를 false로 바꾸는 대신 관련 매개변수 코드를 삭제.

