### PR TITLE
등급 미달 멤버의 수료증 발급 차단

### DIFF
--- a/src/components/Unqualified/Unqualified.module.css
+++ b/src/components/Unqualified/Unqualified.module.css
@@ -1,0 +1,28 @@
+.unqualified {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100dvh;
+  color: var(--primary);
+
+  > h1 {
+    font-weight: var(--font-weight-medium);
+    font-size: clamp(30px, 4vw, 80px);
+    line-height: clamp(50px, 4vw, 100px);
+  }
+
+  > p {
+    text-align: center;
+    margin: 32px 0 0;
+    color: var(--text-900);
+    font-weight: var(--font-weight-regular);
+    font-size: clamp(12px, 4vw, 16px);
+    line-height: clamp(18px, 4vw, 28px);
+  }
+
+  > a {
+    margin-top: 38px;
+  }
+}

--- a/src/components/Unqualified/Unqualified.stories.tsx
+++ b/src/components/Unqualified/Unqualified.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Unqualified from "./Unqualified";
+
+export default {
+  component: Unqualified,
+} satisfies Meta<typeof Unqualified>;
+
+export const Default: StoryObj<typeof Unqualified> = {
+  args: {},
+};

--- a/src/components/Unqualified/Unqualified.stories.tsx
+++ b/src/components/Unqualified/Unqualified.stories.tsx
@@ -5,6 +5,4 @@ export default {
   component: Unqualified,
 } satisfies Meta<typeof Unqualified>;
 
-export const Default: StoryObj<typeof Unqualified> = {
-  args: {},
-};
+export const Default: StoryObj<typeof Unqualified> = {};

--- a/src/components/Unqualified/Unqualified.test.tsx
+++ b/src/components/Unqualified/Unqualified.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import Unqualified from "./Unqualified";
+
+test("renders the heading", () => {
+  render(<Unqualified />);
+
+  expect(
+    screen.getByRole("heading", { name: /you can do it/i }),
+  ).toBeInTheDocument();
+});
+
+test("renders the description", () => {
+  render(<Unqualified />);
+
+  expect(
+    screen.getByText(/조금씩 자라나고 있어요, 곧 멋진 나무가 될 거예요!/),
+  ).toBeInTheDocument();
+});
+
+test("renders the link to the leaderboard page with correct href", () => {
+  render(<Unqualified />);
+
+  const leaderboardLink = screen.getByRole("link", {
+    name: "리더보드로 돌아가기",
+  });
+  expect(leaderboardLink).toHaveAttribute("href", "/");
+});

--- a/src/components/Unqualified/Unqualified.test.tsx
+++ b/src/components/Unqualified/Unqualified.test.tsx
@@ -22,7 +22,7 @@ test("renders the link to the leaderboard page with correct href", () => {
   render(<Unqualified />);
 
   const leaderboardLink = screen.getByRole("link", {
-    name: "리더보드로 돌아가기",
+    name: /리더보드로 돌아가기/,
   });
   expect(leaderboardLink).toHaveAttribute("href", "/");
 });

--- a/src/components/Unqualified/Unqualified.tsx
+++ b/src/components/Unqualified/Unqualified.tsx
@@ -1,0 +1,19 @@
+import Link from "../Link/Link";
+
+import styles from "./Unqualified.module.css";
+
+export default function Unqualified() {
+  return (
+    <section className={styles.unqualified}>
+      <h1>YOU CAN DO IT 💪</h1>
+      <p>
+        조금씩 자라나고 있어요, 곧 멋진 나무가 될 거예요!
+        <br />
+        가지 이상 등급 달성 후 수료증 발급이 가능합니다.
+      </p>
+      <Link variant="secondaryButton" href="/">
+        리더보드로 돌아가기
+      </Link>
+    </section>
+  );
+}

--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -66,6 +66,32 @@ test("display error message if member is not found", () => {
   expect(heading).toHaveTextContent("Page Not Found");
 });
 
+test("display error message if member is unqualified", () => {
+  location.href = new URL(`?member=test1`, location.href).toString();
+  vi.mocked(useMembers).mockReturnValue(
+    mock({
+      isLoading: false,
+      error: null,
+      members: [
+        mock<Member>({
+          id: "test1",
+          name: "테스트1",
+          grade: "LEAF",
+          cohorts: [1],
+        }),
+      ],
+      totalCohorts: 0,
+      filter: { name: "", cohort: null },
+      setFilter: vi.fn(),
+    }),
+  );
+
+  render(<Certificate />);
+
+  const heading = screen.getByRole("heading", { level: 1 });
+  expect(heading).toHaveTextContent(/you can do it/i);
+});
+
 test("render page title", () => {
   vi.mocked(useMembers).mockReturnValue(
     mock({
@@ -249,7 +275,7 @@ test("render LinkedIn link", () => {
         mock<Member>({
           id: "test1",
           name: "테스트1",
-          grade: "SEED",
+          grade: "FRUIT",
           cohorts: [1],
         }),
       ],
@@ -266,7 +292,7 @@ test("render LinkedIn link", () => {
     name: "링크드인 공유",
   });
 
-  const certificateName = `Leetcode 75 ${gradeEmojiMap["SEED"]}`;
+  const certificateName = `Leetcode 75 ${gradeEmojiMap["FRUIT"]}`;
   const params = new URLSearchParams({
     startTask: "CERTIFICATION_NAME",
     name: certificateName,

--- a/src/pages/Certificate/Certificate.tsx
+++ b/src/pages/Certificate/Certificate.tsx
@@ -6,6 +6,7 @@ import Button from "../../components/Button/Button";
 import Layout from "../../components/Layout/Layout";
 import Link from "../../components/Link/Link";
 import NotFound from "../../components/NotFound/NotFound";
+import Unqualified from "../../components/Unqualified/Unqualified";
 import Spinner from "../../components/Spinner/Spinner";
 import ServerError from "../../components/ServerError/ServerError";
 
@@ -51,6 +52,14 @@ export default function Certificate() {
     return (
       <Layout>
         <NotFound />
+      </Layout>
+    );
+  }
+
+  if (["SEED", "SPROUT", "LEAF"].includes(member.grade)) {
+    return (
+      <Layout>
+        <Unqualified />
       </Layout>
     );
   }


### PR DESCRIPTION
수료증 발급 기준에 미달하는 멤버의 수료증 버튼을 클릭하였을 경우 수료증 화면 대신에 응원하는 메시지를 보여주도록 수정하였습니다.

https://github.com/user-attachments/assets/6b56a0f2-4510-49e1-9fb5-02a1fbdd12ba

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [x] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
