### PR TITLE
페이지네이션을 위한 useMembers 후크 함수 수정 

### DIFF
--- a/src/hooks/usePagination.test.ts
+++ b/src/hooks/usePagination.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook } from "@testing-library/react";
+import { expect, test } from "vitest";
+import usePagination from "./usePagination";
+
+test("initial state is set correctly", () => {
+  const { result } = renderHook(() => usePagination({ totalItems: [] }));
+
+  expect(result.current.current).toBe(1);
+  expect(result.current.totalPages).toBe(0);
+  expect(result.current.items).toEqual([]);
+});
+
+test("pagination calculates totalPages correctly", () => {
+  const items = Array.from({ length: 25 }, (_, i) => i + 1);
+  const { result } = renderHook(() =>
+    usePagination({ totalItems: items, pageSize: 10 }),
+  );
+
+  expect(result.current.totalPages).toBe(3);
+});
+
+test("next and previous page navigation works", () => {
+  const items = Array.from({ length: 25 }, (_, i) => i + 1);
+  const { result } = renderHook(() =>
+    usePagination({ totalItems: items, pageSize: 10 }),
+  );
+
+  act(() => {
+    result.current.goNext();
+  });
+
+  expect(result.current.current).toBe(2);
+
+  act(() => {
+    result.current.goPrevious();
+  });
+
+  expect(result.current.current).toBe(1);
+});
+
+test("items are sliced correctly based on current page", () => {
+  const items = Array.from({ length: 25 }, (_, i) => i + 1);
+  const { result } = renderHook(() =>
+    usePagination({ totalItems: items, pageSize: 10 }),
+  );
+
+  expect(result.current.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+  act(() => {
+    result.current.goNext();
+  });
+
+  expect(result.current.items).toEqual([
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  ]);
+
+  act(() => {
+    result.current.goNext();
+  });
+
+  expect(result.current.items).toEqual([21, 22, 23, 24, 25]);
+});
+
+test("next page does not exceed totalPages", () => {
+  const items = Array.from({ length: 25 }, (_, i) => i + 1);
+  const { result } = renderHook(() =>
+    usePagination({ totalItems: items, pageSize: 10 }),
+  );
+
+  act(() => {
+    result.current.goNext();
+    result.current.goNext();
+    result.current.goNext();
+  });
+
+  expect(result.current.current).toBe(3);
+});
+
+test("previous page does not go below 1", () => {
+  const items = Array.from({ length: 25 }, (_, i) => i + 1);
+  const { result } = renderHook(() =>
+    usePagination({ totalItems: items, pageSize: 10 }),
+  );
+
+  act(() => {
+    result.current.goPrevious();
+  });
+
+  expect(result.current.current).toBe(1);
+});

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+type UsePagination = <Data>(params: {
+  totalItems: Data[];
+  pageSize?: number;
+}) => {
+  current: number;
+  totalPages: number;
+  items: Data[];
+  goNext: () => void;
+  goPrevious: () => void;
+};
+
+const usePagination: UsePagination = ({ totalItems, pageSize = 8 }) => {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(totalItems.length / pageSize);
+
+  const start = (currentPage - 1) * pageSize;
+  const end = start + pageSize;
+  const items = totalItems.slice(start, end);
+
+  const goNext = () => {
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages));
+  };
+
+  const goPrevious = () => {
+    setCurrentPage((prev) => Math.max(prev - 1, 1));
+  };
+
+  return {
+    current: currentPage,
+    totalPages,
+    items,
+    goNext,
+    goPrevious,
+  };
+};
+
+export default usePagination;

--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -3,8 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { afterAll, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { Member } from "../../api/services/types";
+import type { Member, Problem } from "../../api/services/types";
 import useMembers from "../../hooks/useMembers";
+import { createMockMember, mockUseMembers } from "../../test-utils/useMembers";
+
 import Certificate from "./Certificate";
 import { gradeEmojiMap } from "./constants";
 
@@ -16,14 +18,7 @@ afterAll(() => {
 
 test("render the loading message while fetching members", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: true,
-      error: null,
-      members: [],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, isLoading: true }),
   );
 
   render(<Certificate />);
@@ -33,14 +28,7 @@ test("render the loading message while fetching members", () => {
 
 test("render the error message while fetching members", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: new Error(),
-      members: [],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, error: new Error() }),
   );
 
   render(<Certificate />);
@@ -49,16 +37,7 @@ test("render the error message while fetching members", () => {
 });
 
 test("display error message if member is not found", () => {
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+  vi.mocked(useMembers).mockReturnValue(mock(mockUseMembers));
 
   render(<Certificate />);
 
@@ -94,14 +73,7 @@ test("display error message if member is unqualified", () => {
 
 test("render page title", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [mock<Member>({ id: "test1", name: "테스트1", cohorts: [1] })],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, members: [createMockMember({ id: "test1" })] }),
   );
 
   location.href = new URL(`?member=test1`, location.href).toString();
@@ -113,28 +85,11 @@ test("render page title", () => {
 
 test("render content id", () => {
   const members = [
-    mock<Member>({
-      id: "test1",
-      name: "테스트1",
-      cohorts: [1],
-    }),
-    mock<Member>({
-      id: "test2",
-      name: "테스트2",
-      cohorts: [2],
-    }),
+    createMockMember({ id: "test1" }),
+    createMockMember({ id: "test2" }),
   ];
 
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members,
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+  vi.mocked(useMembers).mockReturnValue(mock({ ...mockUseMembers, members }));
 
   members.forEach(({ id, name }) => {
     location.href = new URL(`?member=${id}`, location.href).toString();
@@ -146,42 +101,30 @@ test("render content id", () => {
 
 test("render content solved problems, cohort", () => {
   const members = [
-    mock<Member>({
-      solvedProblems: Array(5).fill({}),
-      cohorts: [1],
+    createMockMember({
+      solvedProblems: Array(5).fill(mock<Problem>()),
       id: "test1",
-      name: "테스트1",
+      cohorts: [1],
     }),
-    mock<Member>({
-      solvedProblems: Array(10).fill({}),
-      cohorts: [2],
+    createMockMember({
+      solvedProblems: Array(10).fill(mock<Problem>()),
       id: "test2",
-      name: "테스트2",
+      cohorts: [2],
     }),
-    mock<Member>({
-      solvedProblems: Array(20).fill({}),
-      cohorts: [3],
+    createMockMember({
+      solvedProblems: Array(20).fill(mock<Problem>()),
       id: "test3",
-      name: "테스트3",
+      cohorts: [3],
     }),
-    mock<Member>({
-      solvedProblems: Array(75).fill({}),
-      cohorts: [4],
+    createMockMember({
+      solvedProblems: Array(75).fill(mock<Problem>()),
       id: "test4",
-      name: "테스트4",
+      cohorts: [4],
     }),
   ];
 
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members,
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+  vi.mocked(useMembers).mockReturnValue(mock({ ...mockUseMembers, members }));
+
   const cohortSuffix = ["th", "st", "nd", "rd"];
   members.forEach(({ id, solvedProblems, cohorts }) => {
     location.href = new URL(`?member=${id}`, location.href).toString();
@@ -205,12 +148,8 @@ test("render content solved problems, cohort", () => {
 test("render learderboard link", () => {
   vi.mocked(useMembers).mockReturnValue(
     mock({
-      isLoading: false,
-      error: null,
-      members: [mock<Member>({ id: "test1", name: "테스트1", cohorts: [1] })],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
+      ...mockUseMembers,
+      members: [createMockMember({ solvedProblems: [], id: "test1" })],
     }),
   );
 
@@ -308,14 +247,7 @@ test("render LinkedIn link", () => {
 
 test("render the error message while fetching members", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: new Error(),
-      members: [],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, error: new Error() }),
   );
 
   render(<Certificate />);

--- a/src/pages/Certificate/Certificate.test.tsx
+++ b/src/pages/Certificate/Certificate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterAll, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -73,7 +73,10 @@ test("display error message if member is unqualified", () => {
 
 test("render page title", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({ ...mockUseMembers, members: [createMockMember({ id: "test1" })] }),
+    mock({
+      ...mockUseMembers,
+      members: [createMockMember({ id: "test1", grade: "TREE" })],
+    }),
   );
 
   location.href = new URL(`?member=test1`, location.href).toString();
@@ -85,8 +88,8 @@ test("render page title", () => {
 
 test("render content id", () => {
   const members = [
-    createMockMember({ id: "test1" }),
-    createMockMember({ id: "test2" }),
+    createMockMember({ id: "test1", grade: "TREE" }),
+    createMockMember({ id: "test2", grade: "TREE" }),
   ];
 
   vi.mocked(useMembers).mockReturnValue(mock({ ...mockUseMembers, members }));
@@ -105,43 +108,54 @@ test("render content solved problems, cohort", () => {
       solvedProblems: Array(5).fill(mock<Problem>()),
       id: "test1",
       cohorts: [1],
+      grade: "TREE",
     }),
     createMockMember({
       solvedProblems: Array(10).fill(mock<Problem>()),
       id: "test2",
       cohorts: [2],
+      grade: "TREE",
     }),
     createMockMember({
       solvedProblems: Array(20).fill(mock<Problem>()),
       id: "test3",
       cohorts: [3],
+      grade: "TREE",
     }),
     createMockMember({
       solvedProblems: Array(75).fill(mock<Problem>()),
       id: "test4",
       cohorts: [4],
+      grade: "TREE",
     }),
   ];
 
   vi.mocked(useMembers).mockReturnValue(mock({ ...mockUseMembers, members }));
 
   const cohortSuffix = ["th", "st", "nd", "rd"];
-  members.forEach(({ id, solvedProblems, cohorts }) => {
+  members.forEach(async ({ id, solvedProblems, cohorts }) => {
     location.href = new URL(`?member=${id}`, location.href).toString();
     render(<Certificate />);
 
-    screen.getByText(
-      new RegExp(
-        `${solvedProblems.length === 75 ? "all" : solvedProblems.length} problems`,
-        "i",
-      ),
-    );
-    screen.getByText(
-      new RegExp(
-        `${cohorts.at(-1)}${cohortSuffix?.[cohorts.at(-1) ?? 0] ?? "th"}`,
-        "i",
-      ),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          new RegExp(
+            `${solvedProblems.length === 75 ? "all" : solvedProblems.length} problems`,
+            "i",
+          ),
+        ),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText(
+          new RegExp(
+            `${cohorts.at(-1)}${cohortSuffix?.[cohorts.at(-1) ?? 0] ?? "th"}`,
+            "i",
+          ),
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });
 
@@ -149,7 +163,9 @@ test("render learderboard link", () => {
   vi.mocked(useMembers).mockReturnValue(
     mock({
       ...mockUseMembers,
-      members: [createMockMember({ solvedProblems: [], id: "test1" })],
+      members: [
+        createMockMember({ solvedProblems: [], id: "test1", grade: "TREE" }),
+      ],
     }),
   );
 

--- a/src/pages/Leaderboard/Leaderboard.test.tsx
+++ b/src/pages/Leaderboard/Leaderboard.test.tsx
@@ -1,24 +1,17 @@
-import { faker } from "@faker-js/faker";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { type Member } from "../../api/services/types";
+import { createMockMember, mockUseMembers } from "../../test-utils/useMembers";
 import useMembers from "../../hooks/useMembers";
+
 import Leaderboard from "./Leaderboard";
 
 vi.mock("../../hooks/useMembers");
 
 test("render the loading while fetching members", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: true,
-      error: null,
-      members: [],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, isLoading: true }),
   );
 
   render(<Leaderboard />);
@@ -29,15 +22,7 @@ test("render the loading while fetching members", () => {
 describe("error occurred while fetching members", () => {
   test("render the error message", () => {
     vi.mocked(useMembers).mockReturnValue(
-      mock({
-        error: new Error(),
-
-        isLoading: false,
-        members: [],
-        totalCohorts: 0,
-        filter: { name: "", cohort: null },
-        setFilter: vi.fn(),
-      }),
+      mock({ ...mockUseMembers, error: new Error() }),
     );
 
     render(<Leaderboard />);
@@ -54,15 +39,7 @@ describe("error occurred while fetching members", () => {
 
   test("render the report issue link", () => {
     vi.mocked(useMembers).mockReturnValue(
-      mock({
-        error: new Error(),
-
-        isLoading: false,
-        members: [],
-        totalCohorts: 0,
-        filter: { name: "", cohort: null },
-        setFilter: vi.fn(),
-      }),
+      mock({ ...mockUseMembers, error: new Error() }),
     );
 
     render(<Leaderboard />);
@@ -77,16 +54,7 @@ describe("error occurred while fetching members", () => {
 });
 
 test("render the page title", () => {
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+  vi.mocked(useMembers).mockReturnValue(mock(mockUseMembers));
 
   render(<Leaderboard />);
   const heading = screen.getByRole("heading", { level: 1 });
@@ -94,18 +62,9 @@ test("render the page title", () => {
 });
 
 test("render the member cards", () => {
-  const members = [mockMember(), mockMember(), mockMember()];
+  const members = [createMockMember(), createMockMember(), createMockMember()];
 
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members,
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+  vi.mocked(useMembers).mockReturnValue(mock({ ...mockUseMembers, members }));
 
   render(<Leaderboard />);
 
@@ -116,14 +75,7 @@ test("render the member cards", () => {
 
 test("render the search bar", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [mockMember()],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, members: [createMockMember()] }),
   );
 
   render(<Leaderboard />);
@@ -133,35 +85,10 @@ test("render the search bar", () => {
 
 test("render the grade creteria", () => {
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [mockMember()],
-      totalCohorts: 0,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, members: [createMockMember()] }),
   );
 
   render(<Leaderboard />);
 
   expect(screen.getByText(/등급 기준/)).toBeInTheDocument();
 });
-
-function mockMember() {
-  const userName = faker.internet.username();
-  const cohort = faker.number.int({ min: 1, max: 9 });
-  return mock<Member>({
-    id: userName,
-    name: userName,
-    cohorts: [cohort],
-    grade: faker.helpers.arrayElement([
-      "SEED",
-      "SPROUT",
-      "LEAF",
-      "BRANCH",
-      "FRUIT",
-      "TREE",
-    ]),
-  });
-}

--- a/src/pages/Progress/Progress.test.tsx
+++ b/src/pages/Progress/Progress.test.tsx
@@ -1,23 +1,18 @@
-import { faker } from "@faker-js/faker";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { type Member } from "../../api/services/types";
 import useMembers from "../../hooks/useMembers";
 import Progress from "./Progress";
+import { createMockMember, mockUseMembers } from "../../test-utils/useMembers";
 
 vi.mock("../../hooks/useMembers");
 
 test("render the site header", () => {
   vi.mocked(useMembers).mockReturnValue(
     mock({
-      isLoading: false,
-      error: null,
-      members: [mockMember({ id: "sam" })],
-      totalCohorts: 3, // Add missing property
-      filter: { name: "", cohort: null }, // Add missing property
-      setFilter: vi.fn(), // Add mock function
+      ...mockUseMembers,
+      members: [createMockMember({ id: "sam" })],
     }),
   );
 
@@ -33,16 +28,7 @@ test("render the site header", () => {
 });
 
 test("display error message if member is not found", () => {
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [],
-      totalCohorts: 3,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+  vi.mocked(useMembers).mockReturnValue(mock(mockUseMembers));
 
   render(<Progress />);
 
@@ -51,16 +37,7 @@ test("display error message if member is not found", () => {
 });
 
 test("display member is not found when query parameter is not passed", () => {
-  vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [],
-      totalCohorts: 3,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
-  );
+  vi.mocked(useMembers).mockReturnValue(mock(mockUseMembers));
   vi.stubGlobal("location", {
     href: "http://example.com",
   });
@@ -71,7 +48,7 @@ test("display member is not found when query parameter is not passed", () => {
 });
 
 test("render page when query parameter is passed", async () => {
-  const mockedMember = mockMember();
+  const mockedMember = createMockMember();
   const mockedQueryParam = "evan";
 
   mockedMember.id = mockedQueryParam;
@@ -83,14 +60,7 @@ test("render page when query parameter is passed", async () => {
   ];
 
   vi.mocked(useMembers).mockReturnValue(
-    mock({
-      isLoading: false,
-      error: null,
-      members: [mockedMember],
-      totalCohorts: 3,
-      filter: { name: "", cohort: null },
-      setFilter: vi.fn(),
-    }),
+    mock({ ...mockUseMembers, members: [mockedMember] }),
   );
 
   vi.stubGlobal("location", {
@@ -112,14 +82,7 @@ test("render page when query parameter is passed", async () => {
 describe("Server Error", () => {
   test("render error UI when data fetching has error", () => {
     vi.mocked(useMembers).mockReturnValue(
-      mock({
-        isLoading: false,
-        error: new Error("An error occurred"),
-        members: [],
-        totalCohorts: 3,
-        filter: { name: "", cohort: null },
-        setFilter: vi.fn(),
-      }),
+      mock({ ...mockUseMembers, error: new Error("An error occurred") }),
     );
 
     render(<Progress />);
@@ -139,14 +102,7 @@ describe("Server Error", () => {
 
   test("renders empty UI in Sidebar when data fetching has error", () => {
     vi.mocked(useMembers).mockReturnValue(
-      mock({
-        isLoading: false,
-        error: new Error("An error occurred"),
-        members: [],
-        totalCohorts: 3,
-        filter: { name: "", cohort: null },
-        setFilter: vi.fn(),
-      }),
+      mock({ ...mockUseMembers, error: new Error("An error occurred") }),
     );
 
     render(<Progress />);
@@ -160,22 +116,3 @@ describe("Server Error", () => {
     ).not.toBeInTheDocument();
   });
 });
-
-function mockMember({ id = faker.internet.username() }: { id?: string } = {}) {
-  const cohort = faker.number.int({ min: 1, max: 9 });
-  return mock<Member>({
-    id,
-    name: id,
-    cohorts: [cohort],
-    grade: faker.helpers.arrayElement([
-      "SEED",
-      "SPROUT",
-      "LEAF",
-      "BRANCH",
-      "FRUIT",
-      "TREE",
-    ]),
-    profileUrl: faker.internet.url(),
-    solvedProblems: [],
-  });
-}

--- a/src/test-utils/useMembers.ts
+++ b/src/test-utils/useMembers.ts
@@ -1,0 +1,39 @@
+import { faker } from "@faker-js/faker";
+import { mock } from "vitest-mock-extended";
+import type { Member } from "../api/services/types";
+import { vi } from "vitest";
+
+export const mockUseMembers = {
+  members: [],
+  totalCohorts: 0,
+  isLoading: false,
+  error: null,
+  filter: { name: "", cohort: null },
+  pagination: { current: 0, total: 0 },
+  setFilter: vi.fn(),
+};
+
+export function createMockMember({
+  id = faker.internet.username(),
+  name = faker.person.fullName(),
+  cohorts = [faker.number.int({ min: 1, max: 9 })],
+  grade = faker.helpers.arrayElement([
+    "SEED",
+    "SPROUT",
+    "LEAF",
+    "BRANCH",
+    "FRUIT",
+    "TREE",
+  ]),
+  profileUrl = faker.internet.url(),
+  solvedProblems = [],
+}: Partial<Member> = {}) {
+  return mock<Member>({
+    id,
+    name,
+    cohorts,
+    grade,
+    profileUrl,
+    solvedProblems,
+  });
+}


### PR DESCRIPTION
## 구현사항
- useMembers hook이 pagination이라는 객체를 반환하여 현재페이지, 전체페이지를 사용하도록 구현했습니다.
- setPagintaion이라는 훅을 반환하여 페이지단에서 커스텀 가능하도록 구현했습니다.

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
