### PR TITLE
등급 미달 멤버의 수료증 링크 비활성화

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -37,7 +37,11 @@ export default function Card({ id, name, cohorts, grade }: CardProps) {
           <Link href={`/progress?member=${id}`} variant="primaryButton">
             풀이 현황
           </Link>
-          <Link href={`/certificate?member=${id}`} variant="primaryButton">
+          <Link
+            href={`/certificate?member=${id}`}
+            variant="primaryButton"
+            disabled={["SEED", "SPROUT", "LEAF"].includes(grade)}
+          >
             수료증
           </Link>
         </section>

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -30,8 +30,10 @@
   max-height: 30px;
   border-radius: 10px;
 
-  color: var(--bg-100);
-  background-color: var(--bg-400);
+  &:link {
+    color: var(--bg-100);
+    background-color: var(--bg-400);
+  }
 
   &:visited {
     color: var(--bg-100);
@@ -46,6 +48,13 @@
     background-color: var(--bg-400);
     text-decoration: underline;
     font-weight: var(--font-weight-bold);
+  }
+
+  &:not([href]) {
+    color: rgba(22, 11, 70, 0.6);
+    background-color: rgba(22, 11, 70, 0.1);
+    text-decoration: revert;
+    font-weight: revert;
   }
 }
 

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -51,8 +51,8 @@
   }
 
   &:not([href]) {
-    color: rgba(22, 11, 70, 0.6);
-    background-color: rgba(22, 11, 70, 0.1);
+    color: var(--text-900);
+    background-color: rgba(22, 11, 70, 0.3);
     text-decoration: revert;
     font-weight: revert;
   }

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -16,6 +16,21 @@ export default meta;
 
 export const Default: StoryObj<typeof meta> = {};
 
+export const Disabled: StoryObj<typeof meta> = {
+  args: {
+    variant: "primaryButton",
+    disabled: true,
+  },
+  argTypes: {
+    variant: {
+      control: false,
+    },
+    disabled: {
+      control: false,
+    },
+  },
+};
+
 export const PrimaryButton: StoryObj<typeof meta> = {
   args: {
     variant: "primaryButton",

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import { render, screen } from "@testing-library/react";
 import { expect, test } from "vitest";
 
@@ -38,4 +39,29 @@ test("render secondary link", () => {
   const link = screen.getByRole("link", { name: "test" });
   expect(link).toHaveAttribute("href", "https://www.algodale.com");
   expect(link.className).includes(styles.secondaryButton);
+});
+
+test("setting the `disabled` prop to `true` disables the link", () => {
+  render(
+    <Link disabled href="https://www.algodale.com" variant="primaryButton">
+      test
+    </Link>,
+  );
+
+  expect(screen.getByText(/test/i)).toBeInTheDocument();
+  expect(screen.queryByRole("link", { name: "test" })).not.toBeInTheDocument();
+});
+
+test("the `disabled` prop is only supported for the primaryButton variant", () => {
+  const variant = faker.helpers.arrayElement(["text", "secondaryButton"]);
+
+  expect(() =>
+    render(
+      <Link disabled href="https://www.algodale.com" variant={variant}>
+        test
+      </Link>,
+    ),
+  ).toThrow(
+    "The `disabled` prop is only supported for the primaryButton variant",
+  );
 });

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -10,17 +10,27 @@ interface LinkProps
   extends HTMLAttributes<HTMLAnchorElement>,
     AnchorHTMLAttributes<HTMLAnchorElement> {
   variant?: "text" | "primaryButton" | "secondaryButton";
+  disabled?: boolean;
 }
 
 export default function Link({
   variant = "text",
   className,
   children,
+  href,
+  disabled = false,
   ...props
 }: PropsWithChildren<LinkProps>) {
+  if (disabled && variant !== "primaryButton") {
+    throw new Error(
+      "The `disabled` prop is only supported for the primaryButton variant",
+    );
+  }
+
   return (
     <a
       {...props}
+      href={disabled ? undefined : href}
       className={`${styles.default} ${styles[variant]} ${className ?? ""}`}
     >
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,9 @@ a {
   font: inherit;
   margin: 0;
   padding: 0;
+}
+
+a:link {
   cursor: pointer;
 }
 


### PR DESCRIPTION
등급 미달 멤버의 수료증 발급을 차단한 PR #221에 이어서, 등급 미달 멤버의 수료증 링크를 비활성화시켰습니다. 관련해서 `<Link/>` 컴포넌트가 `disabled` 속성을 지원하도록 수정하였습니다.

![Shot 2025-01-25 at 15 19 19](https://github.com/user-attachments/assets/f0843d0a-40dc-448e-99d9-1f72f640ef2f)

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [x] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
