### PR TITLE
페이지 사이즈 증가

### DIFF
--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -11,7 +11,7 @@ type UsePagination = <Data>(params: {
   goPrevious: () => void;
 };
 
-const usePagination: UsePagination = ({ totalItems, pageSize = 8 }) => {
+const usePagination: UsePagination = ({ totalItems, pageSize = 16 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
   const totalPages = Math.ceil(totalItems.length / pageSize);


### PR DESCRIPTION
현재 페이지 사이즈가 8인데 너무 작아서 페이지를 자주 넘나들게 되더라고요. 16으로 증가시키면 좀 더 나은 사용자 경험이 될 것 같습니다. 스크롤링을 좀 더 하더라도 페이지 전환없이 한 화면에 더 많은 데이터를 볼 수 있을테니까요.

## 체크리스트

- [ ] 이슈가 연결되어 있나요?
- [x] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
