### PR TITLE
style: 수료증 페이지 버튼 텍스트 깨짐 스타일 수정

### DIFF
--- a/src/pages/Certificate/Certificate.module.css
+++ b/src/pages/Certificate/Certificate.module.css
@@ -238,7 +238,6 @@
   justify-content: space-between;
 
   & a {
-    flex: 1;
     max-height: 45px;
     height: 45px;
     font-size: 15px;
@@ -251,10 +250,10 @@
   & > div {
     flex: 1;
     display: flex;
-    column-gap: 10px;
+    flex-direction: column;
+    row-gap: 10px;
 
     & > button {
-      max-height: 45px;
       height: 45px;
       font-size: 15px;
     }
@@ -276,6 +275,7 @@
 
     & > div {
       flex: none;
+      flex-direction: row;
       column-gap: 15px;
 
       & > button {


### PR DESCRIPTION
## 변경 전
![image](https://github.com/user-attachments/assets/044bc1d7-3970-41ff-accc-fd7559561fac)


## 변경 후
![image](https://github.com/user-attachments/assets/12af082d-90df-45d9-b47b-ad8c64c99001)

## 체크리스트

- [x] 이슈가 연결되어 있나요?
- [ ] 배포 후 브라우저 콘솔에 경고나 오류가 있나요?
