### PR TITLE
chore: switch graphql endpoint to cloudflare

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ bun run test src/components/Card/Card.test.tsx
 ### Data Flow
 
 ```
-GitHub GraphQL API (https://dalestudy.fly.dev/)
+GitHub GraphQL API (https://graphql.daleseo.workers.dev/)
   ↓ gitHubClient.ts (Apollo Client)
   ↓ fetchService.ts (extract teams, members, submissions)
   ↓ processService.ts (calculate progress & grades)
@@ -178,7 +178,7 @@ export const Default: StoryObj<typeof Card> = {
 
 ### Apollo Client Configuration
 
-- **Endpoint**: `https://dalestudy.fly.dev/`
+- **Endpoint**: `https://graphql.daleseo.workers.dev/`
 - **Cache**: InMemoryCache (default policies)
 - **Location**: `src/api/infra/gitHub/gitHubClient.ts`
 

--- a/src/api/infra/gitHub/gitHubClient.ts
+++ b/src/api/infra/gitHub/gitHubClient.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
 
 const client = new ApolloClient({
-  uri: "https://dalestudy.fly.dev/",
+  uri: "https://graphql.daleseo.workers.dev/",
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
DaleStudy GraphQL API의 배포 플랫폼이 Fly.io에서 Cloudflare Containers로 이전되어(DaleStudy/graphql#10), Apollo Client가 바라보는 엔드포인트를 `https://graphql.daleseo.workers.dev/`로 교체합니다. 같은 GraphOS 그래프(`dalestudy@current`)를 서빙하므로 스키마와 응답 데이터는 기존과 동일하며, 기존 `dalestudy.fly.dev` 주소는 곧 중단될 예정입니다. CLAUDE.md의 아키텍처 문서도 함께 갱신했습니다.

## Testing

로컬에서 서버를 올려서 잘 동작하는지 확인하였습니다.

<img width="3420" height="2034" alt="2026-07-14 at 09 37 55" src="https://github.com/user-attachments/assets/bd2d1295-7dd9-4dc4-bb70-d9236bf41afa" />
